### PR TITLE
chore:(backend:config): add capability of inject os env as config

### DIFF
--- a/backend/src/configuration/config.constants.ts
+++ b/backend/src/configuration/config.constants.ts
@@ -14,3 +14,4 @@ export const ENVIRONMENT_PATH = `environment/${ENVIRONMENT_FILE_NAME}`
 export const STATIC_PATH = path.resolve(path.join(__dirname, IS_TEST_ENV ? '../../../dist/static' : '../../static'))
 export const STATIC_ASSETS_PATH = path.join(STATIC_PATH, 'assets')
 export const APP_LOGS_PATH = path.join(__dirname, '../../logs')
+export const ENV_PREFIX = 'SYNCIN_'

--- a/backend/src/configuration/config.loader.ts
+++ b/backend/src/configuration/config.loader.ts
@@ -8,6 +8,46 @@ import * as yaml from 'js-yaml'
 import fs from 'node:fs'
 import path from 'node:path'
 import { APP_LOGS_PATH, ENVIRONMENT_FILE_NAME, ENVIRONMENT_PATH } from './config.constants'
+import { ENV_PREFIX } from './config.constants'
+
+function configSysEnvLoader(config: any): any {
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.startsWith(ENV_PREFIX)) continue
+
+    const pathParts = key
+      .slice(ENV_PREFIX.length) // remove prefix
+      .toLowerCase()
+      .split('_') // convert to path
+    setNestedConfigValue(config, pathParts, value)
+  }
+
+  return config
+}
+
+function setNestedConfigValue(obj: any, pathParts: string[], value: any) {
+  let current = obj
+  for (let i = 0; i < pathParts.length - 1; i++) {
+    const part = pathParts[i]
+    if (!(part in current)) {
+      // Optionally warn or silently skip
+      return
+    }
+    current = current[part]
+  }
+
+  const finalKey = pathParts[pathParts.length - 1]
+
+  // Try to parse types correctly
+  current[finalKey] = parseEnvValue(value)
+  
+}
+
+function parseEnvValue(value: string): any {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  if (!isNaN(Number(value))) return Number(value)
+  return value
+}
 
 export function configLoader(): any {
   if (!fs.existsSync(APP_LOGS_PATH)) {
@@ -15,8 +55,9 @@ export function configLoader(): any {
   }
   for (const envPath of [path.join(__dirname, `../../../${ENVIRONMENT_PATH}`), `./${ENVIRONMENT_PATH}`, ENVIRONMENT_FILE_NAME]) {
     if (fs.existsSync(envPath) && fs.lstatSync(envPath).isFile()) {
-      return yaml.load(fs.readFileSync(envPath, 'utf8'))
+      return configSysEnvLoader(yaml.load(fs.readFileSync(envPath, 'utf8')))
     }
   }
   throw new Error(`${ENVIRONMENT_FILE_NAME} not found`)
 }
+


### PR DESCRIPTION
# Add OS environment variables for configuration
Hi, I've add some lines to implement configuration injection from environment variables for better security into Docker and Kubernetes context.
In my case, I can't create a file with database user and password (mysql_url) directly visible into the "environment.yaml" file.
Usually, I inject into containers env variables from secrets.

## Improvement
With those new lines, all current and future configuration attributes are accessible and override by his env var like "SYNCIN_MYSQL_URL".
I've respected respected your configuration structure.

## Examples
Now you can add env var and secrets into your dockerfile.

### Env inclusion
```yaml
// docker-compose.yaml
services:
  sync_in:
    ...
   environment:
      - SYNCIN_SERVER_HOST=mysql://roberto:pass@localhost
```

### Secret inclusion
```shell
echo "mysql://roberto:pass@localhost" | docker secret create syncin_mysql_url -
```

```yaml
// docker-compose.yaml
services:
  sync_in:
    ...
    secrets:
      - syncin_server_host

secrets:
  syncin_server_host:
    external: true
```