### PR TITLE
fix(frontend:files): keep aspect ratio for images with large width

### DIFF
--- a/frontend/src/app/applications/files/components/dialogs/files-viewer-dialog.component.html
+++ b/frontend/src/app/applications/files/components/dialogs/files-viewer-dialog.component.html
@@ -16,8 +16,8 @@
   <div class="modal-body">
     @switch (currentFile.shortMime) {
       @case ('image') {
-        <div class="d-flex justify-content-center bg-black">
-          <img [src]="currentFile.dataUrl" [style.height.px]="currentHeight" alt="" class="img-fluid align-self-center">
+        <div class="d-flex justify-content-center bg-black" [style.height.px]="currentHeight">
+          <img [src]="currentFile.dataUrl" [style.max-height.px]="currentHeight" alt="" class="img-fluid align-self-center">
         </div>
       }
       @case ('pdf') {

--- a/frontend/src/app/applications/files/components/sidebar/files-selection.component.html
+++ b/frontend/src/app/applications/files/components/sidebar/files-selection.component.html
@@ -32,7 +32,9 @@
           <div class="card-body align-self-center p-0 my-1">
             @switch (f.shortMime) {
               @case ('image') {
-                <img src="{{f.thumbnailUrl}}?size=256" alt="" class="img-fluid" [style.height.px]="cardImageSize">
+                <div class="d-flex align-items-center" [style.height.px]="cardImageSize">
+                  <img src="{{f.thumbnailUrl}}?size=256" alt="" class="img-fluid" [style.max-height.px]="cardImageSize">
+                </div>
               }
               @case ('media') {
                 <app-files-viewer-media [currentHeight]="cardImageSize" [fileUrl]="f.dataUrl"></app-files-viewer-media>


### PR DESCRIPTION
There seems to be an aspect ratio problem with the display of images, especially when their width is greater than their height, including on thumbnails.

**Here's the current behavior:**

_Thumbnail view_
<img width="1154" height="734" alt="1753382843 517682649" src="https://github.com/user-attachments/assets/0d7a1120-032d-4a1b-98aa-5c1ac56c0d44" />

_Image view_
<img width="1154" height="734" alt="1753382905 801686509" src="https://github.com/user-attachments/assets/1a8e1bdb-009a-4642-8a5c-b2aa24fd045d" />

**And here it is after the fix:**

_Thumbnail view_
<img width="1154" height="734" alt="1753383211 306822894" src="https://github.com/user-attachments/assets/785c882e-6899-4352-bd68-0f921749701f" />

_Image view_
<img width="1154" height="734" alt="1753383256 907581819" src="https://github.com/user-attachments/assets/a69b7046-205f-4304-bdc9-a0ceb9d0637b" />

