### PR TITLE
feat(docker): add PUID/PGID env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:22-alpine AS build
-RUN apk update && apk add build-base g++ cairo-dev pango-dev giflib-dev libjpeg-turbo-dev
+RUN apk add --no-cache build-base g++ cairo-dev pango-dev giflib-dev libjpeg-turbo-dev
 WORKDIR /build
 COPY . .
 RUN npm ci && \
@@ -8,20 +8,20 @@ RUN npm ci && \
     npm -w backend ci --omit=dev
 
 FROM node:22-alpine AS sync-in
-RUN addgroup -g 8888 syncin && \
-    adduser -D -u 8888 -G syncin syncin && \
-    apk update && \
-    apk add cairo-dev pango-dev giflib-dev libjpeg-turbo-dev fontconfig ttf-liberation && \
-    mkdir -p /app/data /app/environment && chown -R syncin:syncin /app
+RUN apk add --no-cache cairo-dev pango-dev giflib-dev libjpeg-turbo-dev fontconfig ttf-liberation su-exec && \
+    mkdir -p /app/data /app/environment
 WORKDIR /app
-COPY --from=build --chown=syncin:syncin build/LICENSE .
-COPY --from=build --chown=syncin:syncin build/dist/ .
-COPY --from=build --chown=syncin:syncin build/node_modules ./node_modules
-COPY --from=build --chown=syncin:syncin build/backend/migrations ./migrations
-COPY --from=build --chown=syncin:syncin build/environment/environment.dist.yaml ./environment/environment.dist.yaml
-COPY --from=build --chown=syncin:syncin build/scripts/docker-sync-in-server.sh ./sync-in-server.sh
+COPY --from=build --chown=8888:8888 /build/LICENSE .
+COPY --from=build --chown=8888:8888 /build/dist/ .
+COPY --from=build --chown=8888:8888 /build/node_modules ./node_modules
+COPY --from=build --chown=8888:8888 /build/backend/migrations ./migrations
+COPY --from=build --chown=8888:8888 /build/environment/environment.dist.yaml ./environment/environment.dist.yaml
+COPY --from=build --chown=8888:8888 --chmod=755 /build/scripts/docker-sync-in-server.sh ./sync-in-server.sh
+COPY --from=build --chown=8888:8888 --chmod=755 /build/scripts/docker-entrypoint.sh ./entrypoint.sh
 ENV NODE_ENV=production
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
+ENV PUID=8888
+ENV PGID=8888
 EXPOSE 8080
-USER syncin
-ENTRYPOINT ["/bin/sh", "sync-in-server.sh"]
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["/bin/sh", "sync-in-server.sh"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+: "${PUID:?PUID is not defined}"
+: "${PGID:?PGID is not defined}"
+
+# Create syncin group if needed
+group_name=$(getent group "${PGID}" | cut -d: -f1)
+if [ -z "${group_name}" ]; then
+    addgroup -g "${PGID}" syncin
+    group_name="syncin"
+fi
+
+# Create syncin user if needed
+# NOTE: if the user already exists, we won't change its primary group since su-exec already forces the correct group id
+if ! getent passwd "${PUID}" >/dev/null 2>&1; then
+    adduser -D -u "${PUID}" -G "${group_name}" -s /bin/sh syncin
+fi
+
+# Change application ownership to syncin if needed
+CURRENT_UID=$(stat -c '%u' /app)
+CURRENT_GID=$(stat -c '%g' /app)
+
+if [ "${CURRENT_UID}" != "${PUID}" ] || [ "${CURRENT_GID}" != "${PGID}" ]; then
+    chown -R "${PUID}:${PGID}" /app
+fi
+
+# Launch server as syncin user
+exec su-exec "${PUID}:${PGID}" "$@"


### PR DESCRIPTION
This allows the user to provide custom UID and GID to run the application in a docker context.

> [!CAUTION]
At each startup, all the permissions of the container's `/app` will be set to the provided UID/GID.