### PR TITLE
fix(backend:webdav): avoid body parsing for WebDAV PUT uploads

### DIFF
--- a/backend/src/applications/users/users.e2e-spec.ts
+++ b/backend/src/applications/users/users.e2e-spec.ts
@@ -8,7 +8,7 @@ import { NestFastifyApplication } from '@nestjs/platform-fastify'
 import { appBootstrap } from '../../app.bootstrap'
 import { TokenResponseDto } from '../../authentication/dto/token-response.dto'
 import { AuthManager } from '../../authentication/services/auth-manager.service'
-import { dbCheckConnection, dbCloseConnection } from '../../infrastructure/database/utils'
+import { dbCheckConnection } from '../../infrastructure/database/utils'
 import { API_USERS_AVATAR, API_USERS_ME } from './constants/routes'
 import { USER_ROLE } from './constants/user'
 import { DeleteUserDto } from './dto/delete-user.dto'
@@ -36,7 +36,6 @@ describe('Users (e2e)', () => {
     await expect(
       adminUsersManager.deleteUserOrGuest(userTest.id, userTest.login, { deleteSpace: true, isGuest: false } satisfies DeleteUserDto)
     ).resolves.not.toThrow()
-    await dbCloseConnection(app)
     await app.close()
   })
 

--- a/backend/src/applications/webdav/constants/webdav.ts
+++ b/backend/src/applications/webdav/constants/webdav.ts
@@ -14,6 +14,7 @@ export const NS_PREFIX = 'D'
 export const LOCK_PREFIX = 'urn:uuid:'
 export const XML_CONTENT_TYPE = 'application/xml; charset=utf-8'
 export const HTML_CONTENT_TYPE = 'text/html; charset=utf-8'
+export const WEBDAV_CONTENT_TYPES = ['application/xml', 'text/xml']
 export const WEBDAV_APP_LOCK = 'WebDAV' as const
 
 export const ALLOWED_WEBDAV_METHODS: string = [

--- a/backend/src/applications/webdav/utils/bootstrap.ts
+++ b/backend/src/applications/webdav/utils/bootstrap.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2012-2026 Johan Legrand <johan.legrand@sync-in.com>
+ * This file is part of Sync-in | The open source file sync and share solution
+ * See the LICENSE file for licensing details
+ */
+
+import { NestFastifyApplication } from '@nestjs/platform-fastify'
+import { FastifyInstance } from 'fastify'
+import { HTTP_METHOD, HTTP_WEBDAV_METHOD } from '../../applications.constants'
+import { WEBDAV_NS, WEBDAV_SPACES } from '../constants/routes'
+import { WEBDAV_CONTENT_TYPES } from '../constants/webdav'
+
+/**
+ * Bootstrap WebDAV-specific Nest/Fastify configuration.
+ *
+ * - Enables XML body parsing for WebDAV XML-based methods (PROPFIND/PROPPATCH/etc.)
+ * - Registers additional WebDAV HTTP methods
+ * - Forces binary Content-Type ONLY for WebDAV PUT requests (file uploads)
+ *
+ * Per RFC 4918, PUT is used to create/replace the content of a resource and the
+ * request body must be treated as an opaque stream (even if the file is JSON/XML).
+ */
+export function bootstrapWebDAV(app: NestFastifyApplication, fastifyInstance: FastifyInstance) {
+  // Enable XML body parser for WebDAV XML requests (PROPFIND, PROPPATCH, LOCK, etc.)
+  app.useBodyParser(WEBDAV_CONTENT_TYPES)
+
+  // Register WebDAV-specific HTTP methods
+  for (const method of Object.values(HTTP_WEBDAV_METHOD)) {
+    fastifyInstance.addHttpMethod(method, { hasBody: true })
+  }
+
+  /**
+   * onRequest hook for WebDAV uploads.
+   *
+   * WebDAV clients may send JSON/XML files with a Content-Type that triggers
+   * Fastify's body parsers (application/json, text/plain, application/xml...).
+   * For PUT uploads we must always treat the payload as a raw binary stream.
+   *
+   * This hook forces `application/octet-stream` for WebDAV PUT requests only,
+   * leaving XML-based WebDAV methods unaffected.
+   */
+  fastifyInstance.addHook('onRequest', (req, _reply, done) => {
+    // Only handle WebDAV PUT requests under the WebDAV base path
+    if (req.method !== HTTP_METHOD.PUT) return done()
+    if (!req.originalUrl.startsWith(WEBDAV_SPACES[WEBDAV_NS.WEBDAV].route)) return done()
+
+    req.headers['content-type'] = 'application/octet-stream'
+    return done()
+  })
+}

--- a/backend/src/applications/webdav/webdav.controller.ts
+++ b/backend/src/applications/webdav/webdav.controller.ts
@@ -4,7 +4,7 @@
  * See the LICENSE file for licensing details
  */
 
-import { All, Controller, HttpStatus, Options, Param, Propfind, Req, Res, UseGuards } from '@nestjs/common'
+import { All, Controller, HttpStatus, Options, Param, Propfind, Req, Res, StreamableFile, UseGuards } from '@nestjs/common'
 import { FastifyReply } from 'fastify'
 import { HTTP_METHOD } from '../applications.constants'
 import { SPACE_REPOSITORY } from '../spaces/constants/spaces'
@@ -20,41 +20,45 @@ export class WebDAVController {
   constructor(private readonly webdavMethods: WebDAVMethods) {}
 
   @Options()
-  serverOptions() {
+  serverOptions(): void {
     // OPTIONS method is handled in the `WebDAVProtocolGuard`, return empty response with headers
     return
   }
 
   @Propfind()
-  serverPropFind(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply) {
+  serverPropFind(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply): Promise<string> {
     return this.webdavMethods.propfind(req, res, WEBDAV_NS.SERVER)
   }
 
   @Options(WEBDAV_BASE_PATH)
-  webdavOptions() {
+  webdavOptions(): void {
     // OPTIONS method is handled in the `WebDAVProtocolGuard`, return empty response with headers
     return
   }
 
   @Propfind(WEBDAV_BASE_PATH)
-  async webdavPropfind(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply) {
+  async webdavPropfind(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply): Promise<string> {
     return this.webdavMethods.propfind(req, res, WEBDAV_NS.WEBDAV)
   }
 
   @Options(`${WEBDAV_BASE_PATH}/:repository(^(${WEBDAV_NS.SPACES}|${WEBDAV_NS.TRASH})$)`)
-  repositoriesOptions() {
+  repositoriesOptions(): void {
     // OPTIONS method is handled in the `WebDAVProtocolGuard`
     return
   }
 
   @Propfind(`${WEBDAV_BASE_PATH}/:repository(^(${WEBDAV_NS.SPACES}|${WEBDAV_NS.TRASH})$)`)
-  async repositoriesPropfind(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply, @Param('repository') repository: string) {
+  async repositoriesPropfind(
+    @Req() req: FastifyDAVRequest,
+    @Res({ passthrough: true }) res: FastifyReply,
+    @Param('repository') repository: string
+  ): Promise<string> {
     return this.webdavMethods.propfind(req, res, repository)
   }
 
   @All(`${WEBDAV_BASE_PATH}/*`)
   @UseGuards(SpaceGuard)
-  async files(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply) {
+  async files(@Req() req: FastifyDAVRequest, @Res({ passthrough: true }) res: FastifyReply): Promise<string | StreamableFile> {
     // OPTIONS method is handled in the `WebDAVProtocolGuard`
     switch (req.method) {
       case HTTP_METHOD.PROPFIND:


### PR DESCRIPTION
Fixes #102 

fix(backend:webdav): treat PUT requests as binary streams to avoid body parsing