### PR TITLE
feat(backend:users): add avatar synchronization for OIDC users

### DIFF
--- a/backend/src/applications/files/services/files-manager.service.ts
+++ b/backend/src/applications/files/services/files-manager.service.ts
@@ -516,7 +516,7 @@ export class FilesManager {
 
     // do
     try {
-      await downloadFile(this.http, downloadDto, rPath, space)
+      await downloadFile(this.http, downloadDto, rPath, { space: space })
     } finally {
       // release lock
       await this.filesLockManager.removeLock(fileLock.key)

--- a/backend/src/applications/files/utils/download-file.ts
+++ b/backend/src/applications/files/utils/download-file.ts
@@ -35,7 +35,12 @@ const parts = [
 const regExpPrivateIP = new RegExp(`^(?:${parts.join('|')})$`, 'i')
 const errorRegexpPrivateIP = 'Access to internal IP addresses is forbidden'
 
-export async function downloadFile(http: HttpService, downloadDto: DownloadFileDto, dstPath: string, space?: SpaceEnv) {
+export async function downloadFile(
+  http: HttpService,
+  downloadDto: DownloadFileDto,
+  dstPath: string,
+  options?: { space?: SpaceEnv; getContentInfo?: boolean }
+) {
   // dto must be validated by the caller
   const headRes: AxiosResponse = await http.axiosRef({ method: HTTP_METHOD.HEAD, url: downloadDto.url, maxRedirects: 1 })
   if (regExpPrivateIP.test(headRes.request.socket.remoteAddress)) {
@@ -45,18 +50,22 @@ export async function downloadFile(http: HttpService, downloadDto: DownloadFileD
 
   // attempt to retrieve the Content-Length header
   const contentLength = 'content-length' in headRes.headers ? Number(headRes.headers['content-length']) || null : null
+  if (options?.getContentInfo) {
+    return { contentLength: contentLength, contentType: `${headRes.headers['content-type']}`, lastModified: headRes.headers['last-modified'] }
+  }
+
   if (!contentLength) {
     throw new FileError(HttpStatus.BAD_REQUEST, 'Missing "content-length" header')
   }
 
-  if (space) {
-    if (space.willExceedQuota(contentLength)) {
+  if (options?.space) {
+    if (options.space.willExceedQuota(contentLength)) {
       throw new FileError(HttpStatus.INSUFFICIENT_STORAGE, 'Storage quota will be exceeded')
     }
     // tasking
-    if (space.task.cacheKey) {
-      space.task.props.totalSize = contentLength
-      FileTaskEvent.emit('startWatch', space, FILE_OPERATION.DOWNLOAD, dstPath)
+    if (options.space.task?.cacheKey) {
+      options.space.task.props.totalSize = contentLength
+      FileTaskEvent.emit('startWatch', options.space, FILE_OPERATION.DOWNLOAD, dstPath)
     }
   }
 

--- a/backend/src/applications/users/services/users-manager.service.spec.ts
+++ b/backend/src/applications/users/services/users-manager.service.spec.ts
@@ -1,11 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import bcrypt from 'bcryptjs'
+import fs from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { Readable } from 'node:stream'
 import { AuthManager } from '../../../authentication/auth.service'
 import { comparePassword } from '../../../common/functions'
 import * as imageModule from '../../../common/image'
 import { pngMimeType, svgMimeType } from '../../../common/image'
+import { configuration } from '../../../configuration/config.environment'
 import { Cache } from '../../../infrastructure/cache/services/cache.service'
 import { DB_TOKEN_PROVIDER } from '../../../infrastructure/database/constants'
 import * as filesUtilsModule from '../../files/utils/files'
@@ -44,6 +47,13 @@ describe(UsersManager.name, () => {
   let usersQueriesService: UsersQueries
   let userTest: UserModel
   let deleteUserDto: DeleteUserDto
+  let testDataPath: string
+  const initialFilesPaths = {
+    dataPath: configuration.applications.files.dataPath,
+    usersPath: configuration.applications.files.usersPath,
+    spacesPath: configuration.applications.files.spacesPath,
+    tmpPath: configuration.applications.files.tmpPath
+  }
   const flush = () => new Promise<void>((r) => setImmediate(r))
   const okStream = (d = 'OK') => {
     const s: any = Readable.from([Buffer.from(d)])
@@ -71,6 +81,12 @@ describe(UsersManager.name, () => {
   }
 
   beforeAll(async () => {
+    testDataPath = await fs.mkdtemp(path.join(os.tmpdir(), 'sync-in-users-manager-spec-'))
+    configuration.applications.files.dataPath = testDataPath
+    configuration.applications.files.usersPath = path.join(testDataPath, 'users')
+    configuration.applications.files.spacesPath = path.join(testDataPath, 'spaces')
+    configuration.applications.files.tmpPath = path.join(testDataPath, 'tmp')
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminUsersManager,
@@ -100,6 +116,11 @@ describe(UsersManager.name, () => {
 
   afterAll(async () => {
     await expect(adminUsersManager.deleteUserSpace(userTest.login)).resolves.not.toThrow()
+    configuration.applications.files.dataPath = initialFilesPaths.dataPath
+    configuration.applications.files.usersPath = initialFilesPaths.usersPath
+    configuration.applications.files.spacesPath = initialFilesPaths.spacesPath
+    configuration.applications.files.tmpPath = initialFilesPaths.tmpPath
+    await fs.rm(testDataPath, { recursive: true, force: true })
   })
 
   it('instances + findUser/me/fromUserId + impersonation', async () => {
@@ -271,7 +292,7 @@ describe(UsersManager.name, () => {
 
   it('avatars advanced: generateIsNotExists, failure branches, base64 fallback', async () => {
     await ensurePaths()
-    usersManager.findUser = jest.fn().mockResolvedValue({ getInitials: () => 'UT' } as unknown as UserModel)
+    usersManager.findUser = jest.fn().mockResolvedValue({ login: userTest.login, getInitials: () => 'UT' } as unknown as UserModel)
     const [p, m] = (await usersManager.getAvatar(userTest.login, false, true)) as [string, string]
     expect(fileName(p)).toBe('avatar.png')
     expect(m).toBe(pngMimeType)
@@ -289,7 +310,7 @@ describe(UsersManager.name, () => {
     const t = okStream('OK')
     t.truncated = true
     const mvSpy = jest.spyOn(filesUtilsModule, 'moveFiles').mockResolvedValue(undefined)
-    await expect(usersManager.updateAvatar(mkReq('image/png', t) as any)).rejects.toThrow('Image is too large (5MB max)')
+    await expect(usersManager.updateAvatar(mkReq('image/png', t) as any)).rejects.toThrow('Image is too large')
     expect(mvSpy).not.toHaveBeenCalled()
 
     jest.spyOn(filesUtilsModule, 'moveFiles').mockRejectedValue(new Error('mv fail'))

--- a/backend/src/applications/users/services/users-manager.service.ts
+++ b/backend/src/applications/users/services/users-manager.service.ts
@@ -11,7 +11,7 @@ import { FastifyAuthenticatedRequest } from '../../../authentication/interfaces/
 import { JwtIdentityPayload } from '../../../authentication/interfaces/jwt-payload.interface'
 import { ACTION } from '../../../common/constants'
 import { comparePassword, hashPassword } from '../../../common/functions'
-import { generateAvatar, pngMimeType, svgMimeType } from '../../../common/image'
+import { generateAvatar, imgMimeTypePrefix, pngMimeType, svgMimeType } from '../../../common/image'
 import { createLightSlug, genPassword } from '../../../common/shared'
 import { configuration, serverConfig } from '../../../configuration/config.environment'
 import { isPathExists, moveFiles, sanitizeName } from '../../files/utils/files'
@@ -40,7 +40,7 @@ import { UserModel } from '../models/user.model'
 import type { Group } from '../schemas/group.interface'
 import type { UserGroup } from '../schemas/user-group.interface'
 import type { User } from '../schemas/user.interface'
-import { USER_AVATAR_FILE_NAME, USER_AVATAR_MAX_UPLOAD_SIZE, USER_DEFAULT_AVATAR_FILE_PATH } from '../utils/avatar'
+import { saveAvatarMetadata, USER_AVATAR_FILE_NAME, USER_AVATAR_MAX_UPLOAD_SIZE, USER_DEFAULT_AVATAR_FILE_PATH } from '../utils/avatar'
 import { AdminUsersManager } from './admin-users-manager.service'
 import { UsersQueries } from './users-queries.service'
 
@@ -144,7 +144,7 @@ export class UsersManager {
 
   async updateAvatar(req: FastifyAuthenticatedRequest) {
     const part: MultipartFile = await req.file({ limits: { fileSize: USER_AVATAR_MAX_UPLOAD_SIZE } })
-    if (!part.mimetype.startsWith('image/')) {
+    if (!part.mimetype.startsWith(imgMimeTypePrefix)) {
       throw new HttpException('Unsupported file type', HttpStatus.BAD_REQUEST)
     }
     const dstPath = path.join(req.user.tmpPath, USER_AVATAR_FILE_NAME)
@@ -156,10 +156,12 @@ export class UsersManager {
     }
     if (part.file.truncated) {
       this.logger.warn({ tag: this.updateAvatar.name, msg: `image is too large` })
-      throw new HttpException('Image is too large (5MB max)', HttpStatus.PAYLOAD_TOO_LARGE)
+      throw new HttpException('Image is too large', HttpStatus.PAYLOAD_TOO_LARGE)
     }
+    const avatarPath = path.join(req.user.homePath, USER_AVATAR_FILE_NAME)
     try {
-      await moveFiles(dstPath, path.join(req.user.homePath, USER_AVATAR_FILE_NAME), true)
+      await moveFiles(dstPath, avatarPath, true)
+      void saveAvatarMetadata(req.user.login, 'user')
     } catch (e) {
       this.logger.error({ tag: this.updateAvatar.name, msg: `${e}` })
       throw new HttpException('Unable to create avatar', HttpStatus.INTERNAL_SERVER_ERROR)
@@ -214,6 +216,7 @@ export class UsersManager {
     const avatarStream: NodeJS.ReadableStream = await generateAvatar(user.getInitials())
     try {
       await pipeline(avatarStream, avatarFile)
+      void saveAvatarMetadata(user.login, 'local')
     } catch (e) {
       this.logger.error({ tag: this.getAvatar.name, msg: `${e}` })
       throw new HttpException('Unable to create avatar', HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/src/applications/users/utils/avatar.ts
+++ b/backend/src/applications/users/utils/avatar.ts
@@ -3,12 +3,48 @@ import { convertImageToBase64 } from '../../../common/image'
 import { STATIC_ASSETS_PATH } from '../../../configuration/config.constants'
 import { isPathExists } from '../../files/utils/files'
 import { UserModel } from '../models/user.model'
+import { readFile, writeFile } from 'node:fs/promises'
+import fs from 'fs/promises'
 
 export const USER_DEFAULT_AVATAR_FILE_PATH = path.join(STATIC_ASSETS_PATH, 'avatar.svg')
 export const USER_AVATAR_FILE_NAME = 'avatar.png'
+export const USER_AVATAR_INFO = 'avatar.json' // used to determine if the avatar must be updated (oidc/ldap case)
 export const USER_AVATAR_MAX_UPLOAD_SIZE = 1024 * 1024 * 5 // 5MB
+
+export interface AvatarInfo {
+  origin: string
+  size: number
+  lastModified?: string
+}
 
 export async function getAvatarBase64(userLogin: string): Promise<string> {
   const userAvatarPath = path.join(UserModel.getHomePath(userLogin), USER_AVATAR_FILE_NAME)
   return convertImageToBase64((await isPathExists(userAvatarPath)) ? userAvatarPath : USER_DEFAULT_AVATAR_FILE_PATH)
+}
+
+export async function saveAvatarMetadata(userLogin: string, origin: string, size?: number, lastModified?: string): Promise<void> {
+  const userAvatarInfoPath = path.join(UserModel.getHomePath(userLogin), USER_AVATAR_INFO)
+  try {
+    if (size === undefined || lastModified === undefined) {
+      const userAvatarPath = path.join(UserModel.getHomePath(userLogin), USER_AVATAR_FILE_NAME)
+      const stats = await fs.stat(userAvatarPath)
+      size ??= stats.size
+      lastModified ??= stats.mtime.toUTCString()
+    }
+    await writeFile(userAvatarInfoPath, JSON.stringify({ origin, size, lastModified } satisfies AvatarInfo))
+  } catch {
+    // ignore
+  }
+}
+
+export async function isAvatarMetadataUnchanged(userLogin: string, origin: string, size: number, lastModified: string): Promise<boolean> {
+  const userAvatarInfoPath = path.join(UserModel.getHomePath(userLogin), USER_AVATAR_INFO)
+  if (!(await isPathExists(userAvatarInfoPath))) return false
+  let avatarInfo: AvatarInfo
+  try {
+    avatarInfo = JSON.parse(await readFile(userAvatarInfoPath, 'utf8'))
+  } catch {
+    return false
+  }
+  return avatarInfo?.origin === origin && avatarInfo?.size === size && avatarInfo?.lastModified === lastModified
 }

--- a/backend/src/authentication/providers/oidc/auth-provider-oidc.service.spec.ts
+++ b/backend/src/authentication/providers/oidc/auth-provider-oidc.service.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatus } from '@nestjs/common'
+import { HttpService } from '@nestjs/axios'
 import { Test, TestingModule } from '@nestjs/testing'
 import {
   authorizationCodeGrant,
@@ -10,8 +11,13 @@ import {
   randomState
 } from 'openid-client'
 import { USER_ROLE } from '../../../applications/users/constants/user'
+import { UserModel } from '../../../applications/users/models/user.model'
 import { AdminUsersManager } from '../../../applications/users/services/admin-users-manager.service'
 import { UsersManager } from '../../../applications/users/services/users-manager.service'
+import * as avatarUtils from '../../../applications/users/utils/avatar'
+import * as filesUtils from '../../../applications/files/utils/files'
+import * as downloadFileUtils from '../../../applications/files/utils/download-file'
+import * as imageUtils from '../../../common/image'
 import { OAuthCookie } from './auth-oidc.constants'
 import { AuthProviderOIDC } from './auth-provider-oidc.service'
 
@@ -85,6 +91,9 @@ describe(AuthProviderOIDC.name, () => {
     createUserOrGuest: jest.Mock
     updateUserOrGuest: jest.Mock
   }
+  let httpService: {
+    axiosRef: jest.Mock
+  }
 
   const makeConfig = (supportsPKCE = true) => ({
     serverMetadata: () => ({
@@ -110,9 +119,17 @@ describe(AuthProviderOIDC.name, () => {
       createUserOrGuest: jest.fn(),
       updateUserOrGuest: jest.fn()
     }
+    httpService = {
+      axiosRef: jest.fn()
+    }
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [{ provide: UsersManager, useValue: usersManager }, { provide: AdminUsersManager, useValue: adminUsersManager }, AuthProviderOIDC]
+      providers: [
+        { provide: HttpService, useValue: httpService },
+        { provide: UsersManager, useValue: usersManager },
+        { provide: AdminUsersManager, useValue: adminUsersManager },
+        AuthProviderOIDC
+      ]
     }).compile()
 
     module.useLogger(['fatal'])
@@ -260,5 +277,88 @@ describe(AuthProviderOIDC.name, () => {
       USER_ROLE.ADMINISTRATOR
     )
     expect(result.role).toBe(USER_ROLE.ADMINISTRATOR)
+  })
+
+  describe('updatePictureUrl', () => {
+    const oidcUser = { login: 'alice', tmpPath: '/tmp/sync-in/alice/tmp' } as UserModel
+    const userInfo = (picture = 'https://cdn.example.test/avatar.jpg') => ({ picture }) as any
+
+    it('returns when picture url is invalid', async () => {
+      const downloadSpy = jest.spyOn(downloadFileUtils, 'downloadFile')
+
+      await (service as any).updatePictureUrl(oidcUser, userInfo('not-a-url'))
+
+      expect(downloadSpy).not.toHaveBeenCalled()
+    })
+
+    it('stops when content type is not an image', async () => {
+      const downloadSpy = jest.spyOn(downloadFileUtils, 'downloadFile').mockResolvedValueOnce({
+        contentType: 'text/plain',
+        contentLength: 123,
+        lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT'
+      } as any)
+      const convertSpy = jest.spyOn(imageUtils, 'convertTempImageToPng').mockResolvedValue(undefined)
+
+      await (service as any).updatePictureUrl(oidcUser, userInfo())
+
+      expect(downloadSpy).toHaveBeenCalledTimes(1)
+      expect(convertSpy).not.toHaveBeenCalled()
+    })
+
+    it('skips update when avatar metadata is unchanged', async () => {
+      const downloadSpy = jest.spyOn(downloadFileUtils, 'downloadFile').mockResolvedValueOnce({
+        contentType: 'image/png',
+        contentLength: 128,
+        lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT'
+      } as any)
+      jest.spyOn(avatarUtils, 'isAvatarMetadataUnchanged').mockResolvedValue(true)
+      const convertSpy = jest.spyOn(imageUtils, 'convertTempImageToPng').mockResolvedValue(undefined)
+
+      await (service as any).updatePictureUrl(oidcUser, userInfo())
+
+      expect(downloadSpy).toHaveBeenCalledTimes(1)
+      expect(convertSpy).not.toHaveBeenCalled()
+    })
+
+    it('downloads and converts avatar when checks pass', async () => {
+      const downloadSpy = jest
+        .spyOn(downloadFileUtils, 'downloadFile')
+        .mockResolvedValueOnce({
+          contentType: 'image/png',
+          contentLength: 128,
+          lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT'
+        } as any)
+        .mockResolvedValueOnce(undefined as any)
+      jest.spyOn(avatarUtils, 'isAvatarMetadataUnchanged').mockResolvedValue(false)
+      jest.spyOn(filesUtils, 'fileSize').mockResolvedValue(1024)
+      jest.spyOn(UserModel, 'getHomePath').mockReturnValue('/tmp/sync-in/users/alice')
+      const convertSpy = jest.spyOn(imageUtils, 'convertTempImageToPng').mockResolvedValue(undefined)
+      const metadataSpy = jest.spyOn(avatarUtils, 'saveAvatarMetadata').mockResolvedValue(undefined)
+
+      await (service as any).updatePictureUrl(oidcUser, userInfo())
+
+      expect(downloadSpy).toHaveBeenCalledTimes(2)
+      expect(convertSpy).toHaveBeenCalledWith('/tmp/sync-in/alice/tmp/avatar.png', '/tmp/sync-in/users/alice/avatar.png')
+      expect(metadataSpy).toHaveBeenCalledWith('alice', 'https://cdn.example.test/avatar.jpg', 128, 'Mon, 01 Jan 2024 00:00:00 GMT')
+    })
+
+    it('stops after download when avatar size exceeds limit', async () => {
+      const downloadSpy = jest
+        .spyOn(downloadFileUtils, 'downloadFile')
+        .mockResolvedValueOnce({
+          contentType: 'image/png',
+          contentLength: 128,
+          lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT'
+        } as any)
+        .mockResolvedValueOnce(undefined as any)
+      jest.spyOn(avatarUtils, 'isAvatarMetadataUnchanged').mockResolvedValue(false)
+      jest.spyOn(filesUtils, 'fileSize').mockResolvedValue(avatarUtils.USER_AVATAR_MAX_UPLOAD_SIZE + 1)
+      const convertSpy = jest.spyOn(imageUtils, 'convertTempImageToPng').mockResolvedValue(undefined)
+
+      await (service as any).updatePictureUrl(oidcUser, userInfo())
+
+      expect(downloadSpy).toHaveBeenCalledTimes(2)
+      expect(convertSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/backend/src/authentication/providers/oidc/auth-provider-oidc.service.ts
+++ b/backend/src/authentication/providers/oidc/auth-provider-oidc.service.ts
@@ -1,8 +1,7 @@
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common'
 import path from 'node:path'
-import { writeFile } from 'node:fs/promises'
+import fs from 'node:fs/promises'
 import { FastifyReply, FastifyRequest } from 'fastify'
-import sharp from 'sharp'
 import {
   allowInsecureRequests,
   authorizationCodeGrant,
@@ -26,8 +25,13 @@ import type { CreateUserDto, UpdateUserDto } from '../../../applications/users/d
 import { UserModel } from '../../../applications/users/models/user.model'
 import { AdminUsersManager } from '../../../applications/users/services/admin-users-manager.service'
 import { UsersManager } from '../../../applications/users/services/users-manager.service'
-import { USER_AVATAR_FILE_NAME, USER_AVATAR_MAX_UPLOAD_SIZE } from '../../../applications/users/utils/avatar'
-import { generateShortUUID, splitFullName } from '../../../common/functions'
+import {
+  isAvatarMetadataUnchanged,
+  saveAvatarMetadata,
+  USER_AVATAR_FILE_NAME,
+  USER_AVATAR_MAX_UPLOAD_SIZE
+} from '../../../applications/users/utils/avatar'
+import { generateShortUUID, splitFullName, transformAndValidate } from '../../../common/functions'
 import { configuration } from '../../../configuration/config.environment'
 import { AUTH_ROUTE } from '../../constants/routes'
 import type { AUTH_SCOPE } from '../../constants/scope'
@@ -37,6 +41,11 @@ import { AuthProvider } from '../auth-providers.models'
 import { OAuthDesktopCallBackURI, OAuthDesktopLoopbackPorts, OAuthDesktopPortParam } from './auth-oidc-desktop.constants'
 import type { AuthProviderOIDCConfig } from './auth-oidc.config'
 import { OAuthCookie, OAuthCookieSettings, OAuthTokenEndpoint } from './auth-oidc.constants'
+import { HttpService } from '@nestjs/axios'
+import { DownloadFileDto } from '../../../applications/files/dto/file-operations.dto'
+import { downloadFile } from '../../../applications/files/utils/download-file'
+import { convertTempImageToPng, imgMimeTypePrefix } from '../../../common/image'
+import { fileSize } from '../../../applications/files/utils/files'
 
 @Injectable()
 export class AuthProviderOIDC implements AuthProvider {
@@ -46,6 +55,7 @@ export class AuthProviderOIDC implements AuthProvider {
   private config: Configuration = null
 
   constructor(
+    private readonly http: HttpService,
     private readonly usersManager: UsersManager,
     private readonly adminUsersManager: AdminUsersManager
   ) {}
@@ -303,19 +313,8 @@ export class AuthProviderOIDC implements AuthProvider {
 
     // Create or update user
     user = await this.updateOrCreateUser(identity, user)
-
-    const avatarUrl = this.extractAvatarUrl(userInfo)
-    if (avatarUrl) {
-      try {
-        await this.syncOIDCAvatar(user, avatarUrl)
-      } catch (e) {
-        this.logger.warn({
-          tag: this.processUserInfo.name,
-          msg: `unable to sync OIDC avatar for *${user.login}* : ${e}`
-        })
-      }
-    }
-
+    // Update picture url (if it exists)
+    await this.updatePictureUrl(user, userInfo)
     // Update user access log
     this.usersManager.updateAccesses(user, ip, true).catch((e: Error) => this.logger.error({ tag: this.processUserInfo.name, msg: `${e}` }))
 
@@ -411,66 +410,78 @@ export class AuthProviderOIDC implements AuthProvider {
     return user
   }
 
-  private extractAvatarUrl(userInfo: UserInfoResponse): string | null {
-    const picture = (userInfo as Record<string, unknown>).picture
+  private async updatePictureUrl(user: UserModel, userInfo: UserInfoResponse): Promise<void> {
+    const picture = userInfo.picture
 
-    if (typeof picture !== 'string') {
-      return null
-    }
+    if (typeof picture !== 'string') return
 
-    const avatarUrl = picture.trim()
-    if (!avatarUrl) {
-      return null
-    }
+    const pictureUrl = picture.trim()
+    if (!pictureUrl) return
 
+    // validate URL
+    let downloadDto: DownloadFileDto
     try {
-      const url = new URL(avatarUrl)
-      if (!['http:', 'https:'].includes(url.protocol)) {
-        return null
+      downloadDto = transformAndValidate(DownloadFileDto, { url: pictureUrl })
+    } catch (e) {
+      this.logger.warn({ tag: this.updatePictureUrl.name, msg: `unable to validate picture URL *${pictureUrl}* : ${e}` })
+      return
+    }
+
+    // checks
+    let pictureContentLength: number | undefined
+    let pictureLastModified: string | undefined
+    try {
+      const tmpPicturePath = path.join(user.tmpPath, USER_AVATAR_FILE_NAME)
+      // retrieve headers
+      const { contentType, contentLength, lastModified } = await downloadFile(this.http, downloadDto, tmpPicturePath, { getContentInfo: true })
+      pictureContentLength = contentLength ?? undefined
+      pictureLastModified = lastModified ?? ''
+
+      if (!contentType.startsWith(imgMimeTypePrefix)) {
+        this.logger.warn({ tag: this.updatePictureUrl.name, msg: `picture content type is not an image: ${contentType}` })
+        return
       }
-      return url.toString()
-    } catch {
-      return null
-    }
-  }
 
-  private async syncOIDCAvatar(user: UserModel, avatarUrl: string): Promise<void> {
-    const response = await fetch(avatarUrl, {
-      redirect: 'follow'
-    })
-
-    if (!response.ok) {
-      throw new Error(`avatar download failed with status ${response.status}`)
-    }
-
-    const contentType = response.headers.get('content-type') ?? ''
-    if (!contentType.startsWith('image/')) {
-      throw new Error(`OIDC picture is not an image (${contentType || 'unknown'})`)
-    }
-
-    const contentLengthHeader = response.headers.get('content-length')
-    if (contentLengthHeader) {
-      const contentLength = Number(contentLengthHeader)
-      if (Number.isFinite(contentLength) && contentLength > USER_AVATAR_MAX_UPLOAD_SIZE) {
-        throw new Error(`OIDC picture is too large (${contentLength} bytes)`)
+      if (!pictureContentLength || pictureContentLength > USER_AVATAR_MAX_UPLOAD_SIZE) {
+        this.logger.warn({ tag: this.updatePictureUrl.name, msg: `picture content length is invalid: ${pictureContentLength}` })
+        return
       }
+
+      if (await isAvatarMetadataUnchanged(user.login, pictureUrl, pictureContentLength, pictureLastModified)) {
+        this.logger.warn({ tag: this.updatePictureUrl.name, msg: `avatar metadata unchanged, skipping update` })
+        return
+      }
+    } catch (e) {
+      this.logger.warn({ tag: this.updatePictureUrl.name, msg: `checks failed: ${e}` })
     }
 
-    const arrayBuffer = await response.arrayBuffer()
-    const inputBuffer = Buffer.from(arrayBuffer)
-
-    if (inputBuffer.length > USER_AVATAR_MAX_UPLOAD_SIZE) {
-      throw new Error(`OIDC picture exceeds max size after download (${inputBuffer.length} bytes)`)
+    // download avatar
+    const userAvatarTmpPath = path.join(user.tmpPath, USER_AVATAR_FILE_NAME)
+    try {
+      await downloadFile(this.http, downloadDto, userAvatarTmpPath)
+    } catch (e) {
+      this.logger.warn({ tag: this.updatePictureUrl.name, msg: `download failed: ${e}` })
+      return
     }
 
-    const pngBuffer = await sharp(inputBuffer).rotate().resize(256, 256, { fit: 'cover' }).png().toBuffer()
-
-    if (pngBuffer.length > USER_AVATAR_MAX_UPLOAD_SIZE) {
-      throw new Error(`converted avatar exceeds max size (${pngBuffer.length} bytes)`)
+    // check size
+    const avatarSize = await fileSize(userAvatarTmpPath)
+    if (avatarSize > USER_AVATAR_MAX_UPLOAD_SIZE) {
+      fs.unlink(userAvatarTmpPath).catch(() => undefined)
+      this.logger.warn({ tag: this.updatePictureUrl.name, msg: `avatar size exceeds limit: ${avatarSize}` })
+      return
     }
 
-    const dstPath = path.join(user.homePath, USER_AVATAR_FILE_NAME)
-    await writeFile(dstPath, pngBuffer)
+    // convert
+    const userAvatarPath = path.join(UserModel.getHomePath(user.login), USER_AVATAR_FILE_NAME)
+    try {
+      await convertTempImageToPng(userAvatarTmpPath, userAvatarPath)
+      void saveAvatarMetadata(user.login, pictureUrl, pictureContentLength, pictureLastModified)
+    } catch (e) {
+      this.logger.warn({ tag: this.updatePictureUrl.name, msg: `convert failed: ${e}` })
+    } finally {
+      fs.unlink(userAvatarTmpPath).catch(() => undefined)
+    }
   }
 
   private extractLoginAndEmail(userInfo: UserInfoResponse) {

--- a/backend/src/authentication/providers/oidc/auth-provider-oidc.service.ts
+++ b/backend/src/authentication/providers/oidc/auth-provider-oidc.service.ts
@@ -1,5 +1,8 @@
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common'
+import path from 'node:path'
+import { writeFile } from 'node:fs/promises'
 import { FastifyReply, FastifyRequest } from 'fastify'
+import sharp from 'sharp'
 import {
   allowInsecureRequests,
   authorizationCodeGrant,
@@ -23,6 +26,7 @@ import type { CreateUserDto, UpdateUserDto } from '../../../applications/users/d
 import { UserModel } from '../../../applications/users/models/user.model'
 import { AdminUsersManager } from '../../../applications/users/services/admin-users-manager.service'
 import { UsersManager } from '../../../applications/users/services/users-manager.service'
+import { USER_AVATAR_FILE_NAME, USER_AVATAR_MAX_UPLOAD_SIZE } from '../../../applications/users/utils/avatar'
 import { generateShortUUID, splitFullName } from '../../../common/functions'
 import { configuration } from '../../../configuration/config.environment'
 import { AUTH_ROUTE } from '../../constants/routes'
@@ -300,6 +304,18 @@ export class AuthProviderOIDC implements AuthProvider {
     // Create or update user
     user = await this.updateOrCreateUser(identity, user)
 
+    const avatarUrl = this.extractAvatarUrl(userInfo)
+    if (avatarUrl) {
+      try {
+        await this.syncOIDCAvatar(user, avatarUrl)
+      } catch (e) {
+        this.logger.warn({
+          tag: this.processUserInfo.name,
+          msg: `unable to sync OIDC avatar for *${user.login}* : ${e}`
+        })
+      }
+    }
+
     // Update user access log
     this.usersManager.updateAccesses(user, ip, true).catch((e: Error) => this.logger.error({ tag: this.processUserInfo.name, msg: `${e}` }))
 
@@ -393,6 +409,68 @@ export class AuthProviderOIDC implements AuthProvider {
     }
 
     return user
+  }
+
+  private extractAvatarUrl(userInfo: UserInfoResponse): string | null {
+    const picture = (userInfo as Record<string, unknown>).picture
+
+    if (typeof picture !== 'string') {
+      return null
+    }
+
+    const avatarUrl = picture.trim()
+    if (!avatarUrl) {
+      return null
+    }
+
+    try {
+      const url = new URL(avatarUrl)
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        return null
+      }
+      return url.toString()
+    } catch {
+      return null
+    }
+  }
+
+  private async syncOIDCAvatar(user: UserModel, avatarUrl: string): Promise<void> {
+    const response = await fetch(avatarUrl, {
+      redirect: 'follow'
+    })
+
+    if (!response.ok) {
+      throw new Error(`avatar download failed with status ${response.status}`)
+    }
+
+    const contentType = response.headers.get('content-type') ?? ''
+    if (!contentType.startsWith('image/')) {
+      throw new Error(`OIDC picture is not an image (${contentType || 'unknown'})`)
+    }
+
+    const contentLengthHeader = response.headers.get('content-length')
+    if (contentLengthHeader) {
+      const contentLength = Number(contentLengthHeader)
+      if (Number.isFinite(contentLength) && contentLength > USER_AVATAR_MAX_UPLOAD_SIZE) {
+        throw new Error(`OIDC picture is too large (${contentLength} bytes)`)
+      }
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    const inputBuffer = Buffer.from(arrayBuffer)
+
+    if (inputBuffer.length > USER_AVATAR_MAX_UPLOAD_SIZE) {
+      throw new Error(`OIDC picture exceeds max size after download (${inputBuffer.length} bytes)`)
+    }
+
+    const pngBuffer = await sharp(inputBuffer).rotate().resize(256, 256, { fit: 'cover' }).png().toBuffer()
+
+    if (pngBuffer.length > USER_AVATAR_MAX_UPLOAD_SIZE) {
+      throw new Error(`converted avatar exceeds max size (${pngBuffer.length} bytes)`)
+    }
+
+    const dstPath = path.join(user.homePath, USER_AVATAR_FILE_NAME)
+    await writeFile(dstPath, pngBuffer)
   }
 
   private extractLoginAndEmail(userInfo: UserInfoResponse) {

--- a/backend/src/common/image.ts
+++ b/backend/src/common/image.ts
@@ -4,13 +4,15 @@ import path from 'node:path'
 import { Readable } from 'node:stream'
 import { promisify } from 'node:util'
 import sharp from 'sharp'
-import TextToSVG from 'text-to-svg' // Sharp settings
+import TextToSVG from 'text-to-svg'
+import { moveFiles } from '../applications/files/utils/files'
 
 // Sharp settings
 sharp.cache(false)
 sharp.concurrency(Math.min(2, os.cpus()?.length || 1))
 
 // Constants
+export const imgMimeTypePrefix = 'image/'
 export const pngMimeType = 'image/png'
 export const svgMimeType = 'image/svg+xml'
 export const webpMimeType = 'image/webp'
@@ -62,6 +64,13 @@ export async function generateAvatar(initials: string): Promise<NodeJS.ReadableS
 export async function convertImageToBase64(imgPath: string) {
   const base64String = await fs.readFile(imgPath, { encoding: 'base64' })
   return `data:image/png;base64,${base64String}`
+}
+
+export async function convertTempImageToPng(temporaryImagePath: string, outputPngPath: string, size = 256): Promise<void> {
+  const srcBuffer = await fs.readFile(temporaryImagePath)
+  const pngBuffer = await sharp(srcBuffer).rotate().resize(size, size, { fit: 'cover' }).png().toBuffer()
+  await fs.writeFile(temporaryImagePath, pngBuffer)
+  await moveFiles(temporaryImagePath, outputPngPath, true)
 }
 
 function randomColor() {


### PR DESCRIPTION
## Summary

Add automatic OIDC avatar import from the standard `picture` claim.

## Details

After successful OIDC login, Sync-in now:

- reads `picture` from `userinfo`
- validates the URL
- downloads the image
- checks content type and size
- converts it to PNG with `sharp`
- stores it as the regular local user avatar

Avatar sync errors are logged but do not prevent login.