### PR TITLE
docs(v2): design and milestone plan for /v2 UI redesign

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,57 @@
+name: Build Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/sync-in-server
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -49,7 +46,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release Workflow
+
 on:
   push:
     tags:
@@ -6,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   create-release:
@@ -25,29 +25,6 @@ jobs:
 
       - name: Build release archives
         run: npm run release:build
-
-      # Publish to DockerHub
-      - name: Docker Login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker Setup Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker Build & Push (multi-arch)
-        run: npm run docker:buildx
-
-      # Publish to NPM (OIDC / Trusted Publishing)
-      - name: Setup Node for npmjs
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          registry-url: 'https://registry.npmjs.org'
-      - name: Publish to npmjs.org
-        working-directory: release/sync-in-server
-        run: npm publish
 
       - name: Extract changelog for current version
         id: changelog

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,72 @@
+name: Upstream Sync
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: upstream-main
+
+      - name: Configure git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Add upstream and fetch
+        run: |
+          git remote add upstream https://github.com/Sync-in/server.git
+          git fetch upstream main
+
+      - name: Fast-forward upstream-main to upstream/main
+        id: sync
+        run: |
+          BEFORE=$(git rev-parse HEAD)
+          git reset --hard upstream/main
+          AFTER=$(git rev-parse HEAD)
+          if [ "$BEFORE" = "$AFTER" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream changes."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "upstream-main: $BEFORE -> $AFTER"
+          fi
+
+      - name: Push upstream-main
+        if: steps.sync.outputs.changed == 'true'
+        run: git push --force-with-lease origin upstream-main
+
+      - name: Open or update PR into main
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin main
+          if git diff --quiet origin/main HEAD; then
+            echo "main already contains upstream-main; skipping PR."
+            exit 0
+          fi
+
+          EXISTING=$(gh pr list --repo "${{ github.repository }}" \
+            --state open --base main --head upstream-main \
+            --json number --jq '.[0].number // empty')
+
+          if [ -z "$EXISTING" ]; then
+            gh pr create --repo "${{ github.repository }}" \
+              --base main --head upstream-main \
+              --title "chore: sync upstream ($(date +%Y-%m-%d))" \
+              --body "Automated upstream sync from \`Sync-in/server\`. Review the diff and merge to pull upstream changes into \`main\`."
+          else
+            echo "PR #$EXISTING already open; the push updates it automatically."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Claude operating notes for this repo
+
+This is a fork of [`Sync-in/server`](https://github.com/Sync-in/server), maintained under `zjean/server`. The workflow is documented in detail in [`docs/plans/2026-04-22-fork-maintenance-design.md`](docs/plans/2026-04-22-fork-maintenance-design.md).
+
+## Branch protection
+
+`main` and `upstream-main` are both protected:
+
+- **`main`** — direct pushes are blocked. All changes (including docs, CI config, trivial fixes) must go through a pull request. The `test` status check must pass and any PR conversations must be resolved before merge.
+- **`upstream-main`** — a pure mirror of `upstream/main`. Only the `upstream-sync.yml` workflow should write to it (force-push allowed; human pushes blocked by PR requirement equivalent).
+
+### Practical implications
+
+- Never attempt `git push origin main` directly. It will be rejected.
+- Every change, even a one-line doc fix, flows: feature branch → push → open PR → wait for `test` green → merge.
+- For upstream merges: the sync workflow opens a PR `upstream-main` → `main`. Review diff, merge via the PR.
+- Customizations follow the naming conventions in the design doc: `custom-` prefix for new files/modules, `mod(<area>): ...` commit prefix for in-place edits to upstream files.
+
+## Upstream and license
+
+- Remote `upstream` → `git@github-prive:Sync-in/server.git` (push intentionally disabled).
+- License is **AGPL-3.0-or-later**. Preserve the `LICENSE` file, keep `"license": "AGPL-3.0-or-later"` in every `package.json`, and never strip upstream copyright headers. If we deploy this for anyone but the maintainer, a user-visible "Source: github.com/zjean/server" link must appear in the UI (§13 network clause).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,73 @@
 # Claude operating notes for this repo
 
-This is a fork of [`Sync-in/server`](https://github.com/Sync-in/server), maintained under `zjean/server`. The workflow is documented in detail in [`docs/plans/2026-04-22-fork-maintenance-design.md`](docs/plans/2026-04-22-fork-maintenance-design.md).
+This is a fork of [`Sync-in/server`](https://github.com/Sync-in/server), maintained under `zjean/server`. Full workflow details live in [`docs/plans/2026-04-22-fork-maintenance-design.md`](docs/plans/2026-04-22-fork-maintenance-design.md). This file is the short, load-bearing version.
 
 ## Branch protection
 
 `main` and `upstream-main` are both protected:
 
 - **`main`** — direct pushes are blocked. All changes (including docs, CI config, trivial fixes) must go through a pull request. The `test` status check must pass and any PR conversations must be resolved before merge.
-- **`upstream-main`** — a pure mirror of `upstream/main`. Only the `upstream-sync.yml` workflow should write to it (force-push allowed; human pushes blocked by PR requirement equivalent).
+- **`upstream-main`** — a pure mirror of `upstream/main`. Only the `upstream-sync.yml` workflow should write to it (force-push allowed; human pushes blocked by PR-equivalent requirement).
 
 ### Practical implications
 
 - Never attempt `git push origin main` directly. It will be rejected.
 - Every change, even a one-line doc fix, flows: feature branch → push → open PR → wait for `test` green → merge.
-- For upstream merges: the sync workflow opens a PR `upstream-main` → `main`. Review diff, merge via the PR.
-- Customizations follow the naming conventions in the design doc: `custom-` prefix for new files/modules, `mod(<area>): ...` commit prefix for in-place edits to upstream files.
+- Feature branches are auto-deleted on merge (`delete_branch_on_merge: true`).
 
-## Upstream and license
+## Branch naming and commit conventions
 
-- Remote `upstream` → `git@github-prive:Sync-in/server.git` (push intentionally disabled).
-- License is **AGPL-3.0-or-later**. Preserve the `LICENSE` file, keep `"license": "AGPL-3.0-or-later"` in every `package.json`, and never strip upstream copyright headers. If we deploy this for anyone but the maintainer, a user-visible "Source: github.com/zjean/server" link must appear in the UI (§13 network clause).
+| Purpose | Branch prefix | Commit prefix |
+|---|---|---|
+| New customization (feature, module, config) | `feat/<topic>` | `feat(<area>): ...` or `custom(<area>): ...` |
+| Bug fix in our code | `fix/<topic>` | `fix(<area>): ...` |
+| Edit to an upstream file (theming, behavior tweak) | `mod/<topic>` | `mod(<area>): ...` |
+| Docs / plans / CI-only changes | `docs/<topic>` or `chore/<topic>` | `docs(...)` / `chore(...)` |
+| Work intended to be PR'd upstream | `upstream-contrib/<topic>` | conventional commits, **no `custom-` paths, no fork-flavored language** — must cherry-pick cleanly onto upstream |
+
+**Upstream-contrib branches must be rooted at `upstream/main`, not `main`.** Example:
+
+```bash
+git fetch upstream
+git checkout -b upstream-contrib/fix-foo upstream/main
+```
+
+### Customization isolation
+
+- **Additions** live under `custom-*` paths (e.g. `backend/src/applications/custom-auth`, `frontend/src/app/applications/custom-dashboard`, `_custom-overrides.scss`). Upstream never touches these — zero merge conflicts.
+- **i18n** keys added by this fork use the `custom.` prefix.
+- **In-place modifications** to upstream files stay small and atomic, with a `mod(<area>): ...` commit message so they're greppable (`git log --grep '^mod('`).
+
+## Merge strategy per PR type
+
+The repo has Squash and Merge-commit both enabled; Rebase is disabled. Pick per PR:
+
+- **Feature / fix / mod / docs / chore PRs → Squash and merge.** Keeps `main`'s history clean; one commit per logical change.
+- **Upstream sync PRs (`upstream-main` → `main`) → Create a merge commit.** Preserves the merge point so upstream history stays legible; full upstream history remains available on the `upstream-main` branch regardless.
+
+GitHub remembers the user's last-used strategy; double-check the dropdown on upstream-sync PRs.
+
+## Versioning and releases
+
+- Version scheme: `<upstream-base>-custom.<n>` — e.g. `2.2.1-custom.1`, `2.2.1-custom.2`, then reset on upstream bump to `2.2.2-custom.1`.
+- `package.json` `version` field holds the current value (root + backend + frontend all align).
+- Releases are cut by tagging `v<version>` on `main`. The tag fires `release.yml` (archives + draft GitHub Release) and `build-image.yml` (versioned image).
+- Image: `ghcr.io/zjean/sync-in-server`. Tags published automatically:
+  - Every push to `main` → `:main`, `:sha-<short>`
+  - Every `v*.*.*` tag → `:<version>`, `:<major>.<minor>`, `:latest`
+  - No DockerHub, no npm publish.
+
+## Upstream remote and license
+
+- Remote `upstream` → `git@github-prive:Sync-in/server.git` (push intentionally disabled via `DISABLE` push URL).
+- Upstream sync is automated: `upstream-sync.yml` runs weekly + on `workflow_dispatch`, force-pushes `upstream/main` → `origin/upstream-main`, and opens a PR into `main` when there's new upstream work.
+- License is **AGPL-3.0-or-later**. Preserve the `LICENSE` file, keep `"license": "AGPL-3.0-or-later"` in every `package.json`, and never strip upstream copyright headers. If this server is deployed for anyone but the maintainer, a user-visible "Source: github.com/zjean/server" link must appear in the UI (§13 network clause).
+
+## Tooling note: `rtk` wrapper
+
+The user runs git/gh via the `rtk` proxy (token savings). A few commands don't pass through cleanly and need `rtk proxy` to bypass:
+
+- `git commit --allow-empty` — rtk's git wrapper rejects `--allow-empty`.
+- `gh api` calls that return JSON — rtk may reshape the output to a schema stub; use `rtk proxy gh api ...` when you need the real response.
+
+Normal `git status`, `git diff`, `gh pr create`, `gh run list`, etc. work unmodified.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+This repository (`zjean/server`) is a fork of `Sync-in/server`
+(https://github.com/Sync-in/server), first forked on 2026-04-22.
+
+The upstream project is licensed under the GNU Affero General Public License,
+version 3 or later (AGPL-3.0-or-later). The full license text is in the
+`LICENSE` file at the root of this repository and applies equally to this fork
+and to all modifications made here.
+
+Per AGPL-3.0 §5(a), files modified in this fork relative to upstream carry
+their modification history via the git log. Modifications to upstream source
+files use commit messages prefixed with `mod(<area>): ...`. New modules and
+files added by this fork are named or located under a `custom-` prefix, and
+new internationalisation keys use a `custom.` prefix.
+
+Per AGPL-3.0 §13, if this software is run on a server and users interact with
+it over a network, the corresponding source code for the modified version must
+be made available to those users. This fork's source is publicly available at
+https://github.com/zjean/server.

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,0 +1,25 @@
+name: sync-in-dev
+
+services:
+  mariadb:
+    image: mariadb:11
+    container_name: sync-in-dev-mariadb
+    restart: unless-stopped
+    command: --innodb_ft_cache_size=16000000 --max-allowed-packet=1G
+    environment:
+      MYSQL_ROOT_PASSWORD: dev_root
+      MYSQL_DATABASE: sync_in
+      MYSQL_USER: sync_in
+      MYSQL_PASSWORD: dev
+    ports:
+      - '3307:3306'
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    healthcheck:
+      test: ['CMD', 'healthcheck.sh', '--connect', '--innodb_initialized']
+      interval: 10s
+      timeout: 5s
+      retries: 6
+
+volumes:
+  mariadb_data:

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,71 @@
+# Local development setup
+
+Runs MariaDB in Docker on host port **3307** (to avoid colliding with any
+system MariaDB/MySQL), while the backend and frontend run directly on the host
+for fast hot reload.
+
+## One-time setup
+
+```bash
+npm ci                                                           # install all workspaces
+cp environment/environment.dev.dist.yaml environment/environment.yaml
+npm run dev:db                                                   # start mariadb, waits for healthcheck
+npm run dev:migrate                                              # create schema
+```
+
+> The backend config loader always reads `environment/environment.yaml` (which is
+> gitignored). The committed `environment.dev.dist.yaml` is a template: copy once,
+> edit if your ports/creds differ.
+
+## Daily workflow
+
+Open two terminals from the repo root:
+
+```bash
+# terminal 1 — backend with --watch (rebuild + restart on save)
+npm run dev:backend
+
+# terminal 2 — frontend with ng serve (HMR + proxy to backend)
+npm run dev:frontend
+```
+
+- Backend: `http://localhost:8080`
+- Frontend dev server: `http://localhost:4200`
+- `ng serve` proxies `/api/*` and `/socket.io` to the backend; open the UI at
+  `http://localhost:4200`.
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `npm run dev:db` | Start MariaDB container, wait for healthcheck |
+| `npm run dev:db:down` | Stop and remove the MariaDB container (keeps the volume) |
+| `npm run dev:db:reset` | Drop the DB volume and re-create it — wipes all dev data |
+| `npm run dev:migrate` | Run drizzle migrations against the dev DB |
+| `npm run dev:backend` | NestJS in `--watch` mode |
+| `npm run dev:frontend` | `ng serve` with `proxy.conf.json` |
+
+## Dev DB access
+
+| | |
+|---|---|
+| Host | `localhost` |
+| Port | `3307` |
+| DB | `sync_in` |
+| User | `sync_in` / `dev` |
+| Root | `root` / `dev_root` |
+
+```bash
+docker exec -it sync-in-dev-mariadb mariadb -usync_in -pdev sync_in
+```
+
+## Troubleshooting
+
+- **Backend can't reach DB** — confirm `npm run dev:db` reported `Healthy`, and
+  that `environment/environment.yaml` points at `mysql://…@localhost:3307/…`.
+- **Frontend calls 404** — check `frontend/proxy.conf.json` maps `/api` and
+  `/socket.io` at your backend port (default 8080).
+- **Port 3307 in use** — edit `docker/docker-compose.dev.yaml` and
+  `environment/environment.yaml` in lockstep.
+- **Schema drift after upstream sync** — `npm run dev:migrate` picks up any
+  new migrations; `npm run dev:db:reset` for a clean slate.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -11,11 +11,16 @@ npm ci                                                           # install all w
 cp environment/environment.dev.dist.yaml environment/environment.yaml
 npm run dev:db                                                   # start mariadb, waits for healthcheck
 npm run dev:migrate                                              # create schema
+npm run dev:seed                                                 # seed admin + sample users/groups
 ```
 
 > The backend config loader always reads `environment/environment.yaml` (which is
 > gitignored). The committed `environment.dev.dist.yaml` is a template: copy once,
 > edit if your ports/creds differ.
+
+After seeding, log in with `sync-in` / `password`. The seed also inserts 10 faker
+users (all `password`) and 5 random groups. Re-running the seed fails on the
+duplicate `sync-in` login — use `npm run dev:db:reset && npm run dev:migrate && npm run dev:seed` for a clean slate.
 
 ## Daily workflow
 
@@ -42,6 +47,7 @@ npm run dev:frontend
 | `npm run dev:db:down` | Stop and remove the MariaDB container (keeps the volume) |
 | `npm run dev:db:reset` | Drop the DB volume and re-create it — wipes all dev data |
 | `npm run dev:migrate` | Run drizzle migrations against the dev DB |
+| `npm run dev:seed` | Seed admin (`sync-in` / `password`) + 10 faker users + 5 groups |
 | `npm run dev:backend` | NestJS in `--watch` mode |
 | `npm run dev:frontend` | `ng serve` with `proxy.conf.json` |
 

--- a/docs/plans/2026-04-22-fork-maintenance-design.md
+++ b/docs/plans/2026-04-22-fork-maintenance-design.md
@@ -1,0 +1,240 @@
+# Fork maintenance design
+
+**Date:** 2026-04-22
+**Upstream:** `Sync-in/sync-in-server` (AGPL-3.0-or-later)
+**Fork:** `zjean/server`
+**Customization prefix:** `custom-`
+
+## Goals
+
+1. Maintain a long-lived fork with our own additions and modifications.
+2. Pull in upstream changes on a cadence, with minimal merge pain.
+3. Publish our own multi-arch Docker images via GitHub Actions.
+4. Retain the ability to contribute selected changes back to upstream.
+5. Stay compliant with the upstream AGPL-3.0-or-later license.
+
+## 1. Branch topology and remotes
+
+### Remotes
+
+- `origin` → `git@github-prive:zjean/server.git` (already set)
+- `upstream` → `git@github-prive:Sync-in/sync-in-server.git` (to add)
+
+```bash
+git remote add upstream git@github-prive:Sync-in/sync-in-server.git
+git remote set-url --push upstream DISABLE  # guard against accidental push
+```
+
+### Branches
+
+| Branch | Role | Write path |
+|---|---|---|
+| `upstream-main` | Exact mirror of upstream `main`. No local commits ever. | Automated mirror workflow only. |
+| `main` | Our product. CI builds images from here. | Merge commits from `upstream-main`; PRs from `feat/*`, `fix/*`, `mod/*`. |
+| `feat/*`, `fix/*`, `mod/*` | Short-lived customization work. | PR into `main`. |
+| `upstream-contrib/<topic>` | Work intended to be PR'd to upstream. Branched from `upstream/main`. | PR to `Sync-in/sync-in-server:main`. |
+
+### Sync cadence
+
+A scheduled GitHub Action mirrors `upstream/main` → `origin/upstream-main` weekly and on manual dispatch. It opens a PR `upstream-main` → `main` whenever there is new upstream work; we review and merge on our own schedule.
+
+Merges always use `--no-ff`, so every upstream pull appears as a visible merge commit. Tag each merge: `merge/upstream-<version>` for scannability.
+
+### Branch protection on `main`
+
+- Require PR
+- Require CI green
+- `upstream-main` is protected but writable by the mirror workflow (bot-only)
+
+## 2. Customization isolation
+
+Additions are kept conflict-free via a `custom-` prefix on new files and directories. Modifications to upstream files are kept small, atomic, and greppable.
+
+### Additions — isolated directories
+
+| Surface | Upstream path | Our customization path |
+|---|---|---|
+| Backend modules | `backend/src/applications/*` | `backend/src/applications/custom-*` |
+| Frontend apps | `frontend/src/app/applications/*` | `frontend/src/app/applications/custom-*` |
+| i18n keys | `frontend/src/i18n/*.json` | Prefix new keys with `custom.` |
+| Env/config | `environment/environment.dist.yaml` | New top-level `custom:` section |
+| SCSS overrides | `frontend/src/styles/components/*` | New file `_custom-overrides.scss`, imported last |
+
+Because upstream never touches `custom-*` paths or `custom.` keys, these additions never produce merge conflicts.
+
+### Modifications — atomic and labeled
+
+For in-place edits (theming, auth tweaks, behavior changes):
+
+- One logical change per commit.
+- Commit message prefix `mod(<area>): ...` so they are greppable:
+  `git log --grep '^mod('`
+- Keep diffs minimal. Prefer adding a CSS variable override in
+  `_custom-overrides.scss` over editing upstream SCSS values.
+- Where feasible, convert a modification into an addition.
+
+### Conflict survival kit
+
+- `git config rerere.enabled true` locally — git remembers conflict resolutions across re-merges.
+- Tag each merge commit from upstream: `merge/upstream-<version>`.
+
+## 3. Contributing back to upstream
+
+The rule: **anything destined for upstream is developed on a branch rooted at `upstream/main`, not `main`.**
+
+### New work intended for upstream
+
+```bash
+git fetch upstream
+git checkout -b upstream-contrib/fix-foo upstream/main
+
+# make changes — no custom- prefix, no fork-flavored commit messages
+
+git push origin upstream-contrib/fix-foo
+gh pr create --repo Sync-in/sync-in-server \
+  --base main \
+  --head zjean:upstream-contrib/fix-foo
+```
+
+### Extracting an already-landed change from `main`
+
+```bash
+git checkout -b upstream-contrib/fix-foo upstream/main
+git cherry-pick <sha-from-main>
+# resolve conflicts against vanilla upstream
+# squash, drop any custom- references, write an upstream-appropriate commit message
+```
+
+Once merged upstream, delete the contrib branch. The change returns to us via the normal `upstream-main` → `main` merge.
+
+### "Should I contribute this back?" heuristic
+
+- Generic bug fix → yes
+- Improvement to an existing upstream feature → usually yes
+- New feature that is broadly useful → offer, but don't block the roadmap on it
+- Branding, opinionated UX, our-business-specific logic → keep in the fork
+
+## 4. CI/CD on GHCR
+
+Target registry: `ghcr.io/zjean/sync-in-server`. Auth uses the built-in `GITHUB_TOKEN`; no extra secrets are required.
+
+### Workflows
+
+**`upstream-sync.yml`** (new)
+- Triggers: weekly `schedule` + `workflow_dispatch`
+- Fetches `upstream/main`, force-pushes to `origin/upstream-main`
+- Opens a PR `upstream-main` → `main` when there are new commits
+
+**`test.yml`** (keep)
+- Existing lint + unit test on push/PR to `main`
+
+**`build-image.yml`** (new — replaces the Docker bits in `release.yml`)
+- Triggers:
+  - `push` to `main` → `:main`, `:sha-<short>`
+  - `push` tag `v*.*.*` → `:X.Y.Z-custom.N`, `:X.Y-custom`, `:latest`
+  - `workflow_dispatch`
+- Steps: checkout → Buildx → GHCR login with `GITHUB_TOKEN` →
+  `docker/metadata-action` for tags → `docker/build-push-action` multi-arch
+  (linux/amd64, linux/arm64)
+- Permissions: `contents: read`, `packages: write`
+
+**`release.yml`** (replace)
+- Trigger: `v*.*.*` tag
+- Keeps: `npm run release:build`, changelog extraction, draft GitHub Release on our repo
+- Drops: DockerHub login, DockerHub push, npm publish (these are upstream-oriented)
+
+### Secrets
+
+None beyond `GITHUB_TOKEN`. Remove `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` from the fork if they were copied across.
+
+## 5. Versioning and release
+
+### Scheme
+
+`<upstream-base>-custom.<n>`
+
+- Upstream on `2.2.1` → our releases are `2.2.1-custom.1`, `2.2.1-custom.2`, …
+- Upstream bumps to `2.2.2` and we merge → next release is `2.2.2-custom.1` (counter resets)
+- `package.json` `version` field holds the current value
+
+### Cutting a release
+
+```bash
+git checkout main && git pull
+npm version 2.2.1-custom.2 --no-git-tag-version
+# edit CHANGELOG.md: add section with upstream base reference
+git add package.json CHANGELOG.md
+git commit -m "chore(release): 2.2.1-custom.2"
+git tag v2.2.1-custom.2
+git push origin main --tags
+```
+
+`release.yml` fires on the tag → archives + draft GitHub Release.
+`build-image.yml` fires on the same tag → pushes `ghcr.io/zjean/sync-in-server:2.2.1-custom.2` plus the floating tags below.
+
+### Handling upstream version bumps during a sync merge
+
+When `upstream-main` → `main` brings an upstream version bump:
+
+1. Accept the upstream version for `package.json` in the merge.
+2. Follow-up commit: append our suffix, e.g. `2.2.2-custom.0` (dev marker).
+3. Reset the CHANGELOG's Unreleased section.
+4. First release on that base is `2.2.2-custom.1`.
+
+### Image tags we can rely on
+
+- `:main` — latest merged code, auto-rebuilt each push
+- `:latest` — most recent release tag
+- `:2.2` — latest release within upstream 2.2.x
+- `:2.2.1-custom` — latest on that exact upstream base
+- `:2.2.1-custom.2` — pinned, immutable
+
+### CHANGELOG
+
+Keep our own `CHANGELOG.md`. Prefix each release section with the upstream base:
+
+```
+## [2.2.1-custom.2] — based on upstream 2.2.1
+```
+
+## 6. License compliance (AGPL-3.0-or-later)
+
+The upstream project is licensed **AGPL-3.0-or-later**. Every decision above is compatible with that license. The following obligations apply.
+
+### Hard requirements
+
+1. **Preserve the `LICENSE` file and every copyright notice in source files.**
+   Never strip or rewrite these. On upstream merges, always accept upstream for `LICENSE` conflicts.
+2. **Modifications inherit AGPL-3.0-or-later.**
+   `custom-*` modules, theming, config — everything we add or change inside this repo is a derivative work and must be AGPL. We cannot ship a proprietary or closed version of anything living in this repo.
+3. **§5(a) — mark modified files.**
+   Maintain a `NOTICE` file at the repo root stating that this is a fork of `Sync-in/sync-in-server`, with the fork date. Modification dates are otherwise tracked via git history and the `mod(...)` commit convention.
+4. **§13 — the network clause.**
+   If the server is run and third parties interact with it over a network, the corresponding source of our modified version must be offered to those users. Practically:
+   - Keep `zjean/server` publicly discoverable on GitHub.
+   - Add a visible "Source: github.com/zjean/server" link in the running UI (footer or `/about`).
+5. **Keep `"license": "AGPL-3.0-or-later"`** in all three `package.json` files (root, `backend`, `frontend`). Never change it.
+
+### Not permitted
+
+- Relicensing any part of this repo to MIT, proprietary, or any non-AGPL terms.
+- Distributing images or binaries to third parties without source availability.
+- Removing upstream copyright attribution.
+- Keeping modifications secret from users of a network-facing deployment.
+
+### Files to add as part of this plan's implementation
+
+- `NOTICE` at repo root — fork attribution and date
+- Small UI change: a "Source" link pointing to the fork (only required if deployed for others)
+
+## 7. Implementation order
+
+1. Add `upstream` remote; create and push `upstream-main` (initial mirror from `upstream/main`).
+2. Add `NOTICE` file.
+3. Enable `git rerere` locally.
+4. Write `.github/workflows/upstream-sync.yml`.
+5. Write `.github/workflows/build-image.yml`.
+6. Rewrite `.github/workflows/release.yml` (drop DockerHub + npm).
+7. Configure GitHub branch protection on `main` and `upstream-main`.
+8. First dry-run release to validate the image pipeline.
+9. Add "Source: github.com/zjean/server" link in UI (when/if deployed for others).

--- a/docs/plans/2026-04-22-fork-maintenance-design.md
+++ b/docs/plans/2026-04-22-fork-maintenance-design.md
@@ -1,7 +1,7 @@
 # Fork maintenance design
 
 **Date:** 2026-04-22
-**Upstream:** `Sync-in/sync-in-server` (AGPL-3.0-or-later)
+**Upstream:** `Sync-in/server` (AGPL-3.0-or-later)
 **Fork:** `zjean/server`
 **Customization prefix:** `custom-`
 
@@ -18,10 +18,10 @@
 ### Remotes
 
 - `origin` → `git@github-prive:zjean/server.git` (already set)
-- `upstream` → `git@github-prive:Sync-in/sync-in-server.git` (to add)
+- `upstream` → `git@github-prive:Sync-in/server.git` (to add)
 
 ```bash
-git remote add upstream git@github-prive:Sync-in/sync-in-server.git
+git remote add upstream git@github-prive:Sync-in/server.git
 git remote set-url --push upstream DISABLE  # guard against accidental push
 ```
 
@@ -32,7 +32,7 @@ git remote set-url --push upstream DISABLE  # guard against accidental push
 | `upstream-main` | Exact mirror of upstream `main`. No local commits ever. | Automated mirror workflow only. |
 | `main` | Our product. CI builds images from here. | Merge commits from `upstream-main`; PRs from `feat/*`, `fix/*`, `mod/*`. |
 | `feat/*`, `fix/*`, `mod/*` | Short-lived customization work. | PR into `main`. |
-| `upstream-contrib/<topic>` | Work intended to be PR'd to upstream. Branched from `upstream/main`. | PR to `Sync-in/sync-in-server:main`. |
+| `upstream-contrib/<topic>` | Work intended to be PR'd to upstream. Branched from `upstream/main`. | PR to `Sync-in/server:main`. |
 
 ### Sync cadence
 
@@ -91,7 +91,7 @@ git checkout -b upstream-contrib/fix-foo upstream/main
 # make changes — no custom- prefix, no fork-flavored commit messages
 
 git push origin upstream-contrib/fix-foo
-gh pr create --repo Sync-in/sync-in-server \
+gh pr create --repo Sync-in/server \
   --base main \
   --head zjean:upstream-contrib/fix-foo
 ```
@@ -208,7 +208,7 @@ The upstream project is licensed **AGPL-3.0-or-later**. Every decision above is 
 2. **Modifications inherit AGPL-3.0-or-later.**
    `custom-*` modules, theming, config — everything we add or change inside this repo is a derivative work and must be AGPL. We cannot ship a proprietary or closed version of anything living in this repo.
 3. **§5(a) — mark modified files.**
-   Maintain a `NOTICE` file at the repo root stating that this is a fork of `Sync-in/sync-in-server`, with the fork date. Modification dates are otherwise tracked via git history and the `mod(...)` commit convention.
+   Maintain a `NOTICE` file at the repo root stating that this is a fork of `Sync-in/server`, with the fork date. Modification dates are otherwise tracked via git history and the `mod(...)` commit convention.
 4. **§13 — the network clause.**
    If the server is run and third parties interact with it over a network, the corresponding source of our modified version must be offered to those users. Practically:
    - Keep `zjean/server` publicly discoverable on GitHub.

--- a/docs/plans/2026-04-22-v2-ui-redesign-design.md
+++ b/docs/plans/2026-04-22-v2-ui-redesign-design.md
@@ -1,0 +1,212 @@
+# Sync-In v2 UI redesign — design and milestone plan
+
+**Status**: design approved, not yet implemented
+**Date**: 2026-04-22
+**Scope decision**: build the redesigned UI at `/v2/*`, alongside the existing UI at `/*`, under the fork's `custom-*` isolation rules.
+
+---
+
+## 0 · Source material and intent
+
+The redesign originates from a Claude Design handoff bundle (`Sync-In Redesign`). The user iterated through several visual directions with the design tool and landed on a polished "in-between" version: minimal but opinionated, warm amber primary accent with indigo nav accent, flat plum title bar, premium type pairing, strict rule that only real product functionality is shown (no invented stats, no fake settings, no speculative columns). The bundle's `Sync-In Redesign.html` + component JSX under `sync-in/project/src/` is the visual reference.
+
+This repo is a fork of `Sync-in/server`. Customization isolation rules apply (`custom-*` paths, `custom.` i18n prefix). The design is a visual + UX overhaul, not a rewrite of upstream behavior — it ships next to the classic UI so upstream merges stay clean.
+
+## 1 · Scope decisions
+
+| Question | Decision |
+|---|---|
+| How does the new UI coexist with the old? | **A. Parallel route tree** — new UI at `/v2/*`, classic UI untouched at `/*`. |
+| First-milestone scope | **Core-browse** — scaffold + chrome + Recents + Personal browser (list view) + Viewer. |
+| Data/services | **Reuse existing Angular services as-is where possible**. Thin adapters only if a service shape doesn't fit the design. |
+| Icons | Port the ~30 custom SVGs from the design bundle; do not reuse FontAwesome for v2. |
+| Typography | Add `@fontsource-variable/geist`, `@fontsource/instrument-serif`, `@fontsource-variable/jetbrains-mono`. |
+
+Milestone 2 explicitly **out of scope**: Spaces, Shared, Trash, File detail page, Transfers popover, grid/gallery browser modes, Search, Settings, People. These are deferred to a milestone-3 plan written after milestone 2 lands.
+
+## 2 · Architecture and layout
+
+### Location
+
+Everything lives under `frontend/src/app/applications/custom-v2/`:
+
+```
+custom-v2/
+├─ v2.routes.ts                 # child routes: recents, personal, viewer
+├─ layout/
+│   ├─ layout-v2.component.{ts,html,scss}
+│   ├─ title-bar.component.*
+│   ├─ app-rail.component.*
+│   ├─ left-nav.component.*
+│   └─ dock-rail.component.*
+├─ screens/
+│   ├─ recents/                 # two-panel Files + Comments
+│   ├─ personal/                # file browser, list-view only for m2
+│   └─ viewer/                  # image viewer
+├─ components/                  # Avatar, AvatarStack, FileGlyph, Logo, Pill, Btn, IconBtn
+├─ icons/                       # SVG icon component (~30 glyphs)
+├─ adapters/                    # optional, only if a service shape needs reshaping
+└─ styles/
+    ├─ _tokens.scss             # SI.* + FILE_COLORS
+    ├─ _mixins.scss
+    └─ v2.scss                  # entry, imported once when /v2 active
+```
+
+### Routing
+
+`app.routes.ts` gains a sibling route group:
+
+```ts
+{
+  path: 'v2',
+  component: LayoutV2Component,
+  canActivate: [authGuard],
+  children: v2Routes,
+}
+```
+
+Classic `LayoutComponent` at `''` is untouched. The `'**'` fallback stays pointed at the classic Recents path. `LayoutV2Component` is a structural mirror of `LayoutComponent` (title bar + rail + nav + `<router-outlet>` + right rail) but in new chrome with v2-scoped SCSS.
+
+### Opt-in UX
+
+- **Primary**: URL prefix (`/v2/recents`, etc.).
+- **Sticky**: `localStorage` key `ui.version` = `'classic' | 'v2'`. If set to `v2`, classic routes redirect the user into their last v2 path on next load.
+- **Discoverability**: a small "Try redesigned UI" link added to the classic navbar's user menu; symmetrical "Back to classic" link in v2's left-nav user card footer.
+- No server-side flag for this milestone — pure client toggle.
+
+### Services
+
+Both layouts inject the same `FilesService`, `SpacesService`, `RecentsService`, `UserService`, `CommentsService`, `LayoutService`, socket.io, auth guards, and l10n. No duplication. If a service exposes shapes that don't match the design's needs, a thin component in `custom-v2/adapters/` reshapes data on the consumer side — the service stays untouched.
+
+## 3 · Design tokens and styling
+
+### Token port
+
+The JSX `SI` object and `FILE_COLORS` map (from `tokens.jsx`) become SCSS custom properties in `custom-v2/styles/_tokens.scss`, scoped under a single `.v2-root` class applied by `LayoutV2Component`. This keeps tokens out of classic routes entirely — no global CSS pollution, no class-name collisions.
+
+```scss
+.v2-root {
+  --si-bg0: #07090d;  --si-bg1: #0d1117;  --si-bg2: #12171f;
+  --si-bg3: #191f28;  --si-bg4: #222935;  --si-bg5: #2d3542;  --si-bg6: #3a4250;
+  --si-line:        rgba(255,255,255,0.055);
+  --si-line-strong: rgba(255,255,255,0.10);
+  --si-line-bold:   rgba(255,255,255,0.16);
+  --si-fg: #f2f3f6;  --si-fg-muted: #a9b1bd;  --si-fg-faint: #6a7280;
+
+  // Accents
+  --si-accent:       oklch(0.76 0.15 55);       // warm amber — primary actions
+  --si-accent-soft:  oklch(0.76 0.15 55 / 0.14);
+  --si-nav:          oklch(0.72 0.17 265);      // indigo — selected nav
+  --si-nav-soft:     oklch(0.72 0.17 265 / 0.16);
+  --si-chrome-bg:    oklch(0.22 0.06 275);      // flat plum (no gradient, per chat2 correction)
+
+  // Semantic + file-type palette, radii (5/8/12/18), shadows, type families …
+}
+```
+
+Fallbacks: tokens SCSS emits hex/rgb fallbacks alongside `oklch()` for browsers that predate color-4 parsing.
+
+### Typography
+
+Three `@fontsource` packages added to `frontend/package.json`:
+
+- `@fontsource-variable/geist` — UI primary
+- `@fontsource/instrument-serif` — editorial italic (e.g. Recents greeting)
+- `@fontsource-variable/jetbrains-mono` — metadata, sizes, timestamps
+
+Imported only from `v2.scss`. Classic stays on its current Inter stack.
+
+### Icon set
+
+The design uses a cohesive 1.5px-stroke SVG icon set (`icons.jsx`: chevLeft, chevRight, chevDown, folder, clock, box, share, person, arrowUp, link, trash, search, settings, pencil, bell, flag, info, shareTree, comment, image, video, doc, sheet, deck, pdf, code, audio, archive, play, plus, upload, more, filter). FontAwesome's visual weight doesn't match. All glyphs are reimplemented as a `IconsV2Component` under `custom-v2/icons/`, size + color via `@Input`.
+
+### Densities & dimensions
+
+40px title bar · 48px app rail · 180px left nav · 40px dock rail — hardcoded but exposed as CSS vars for future tweaks. Radii ladder 5/8/12/18. Shadow ladder (shadow1/2/3) matches the JSX tokens.
+
+## 4 · Chrome components
+
+### `LayoutV2Component`
+
+The v2 root. Adds `.v2-root` class to its host, sets up the 4-zone layout (title bar across top; app rail + left nav + content + dock rail left-to-right), owns the dock-active state, and renders `<router-outlet>` in the content slot. Subscribes to the same `LayoutService` as classic for viewport/theme events, but does **not** reuse classic's `body`-class toggles (`sidebar-collapse`, `control-sidebar-open`) — v2 has its own collapse state on the host component.
+
+### `TitleBarComponent`
+
+Height 40px, flat plum `--si-chrome-bg`. Left-to-right: 168px brand block (conic-gradient `LogoComponent` + "Sync-In" / "FILES" eyebrow) → back/forward nav icon buttons → breadcrumb strip → right-edge slot (`rightBadge` content projection, for the future transfers pill) + user avatar.
+
+Breadcrumb data comes from a new `BreadcrumbService` with a `setBreadcrumbs(segments: { label, icon?, route? }[])` method. Screens push into it on activation.
+
+### `AppRailComponent`
+
+48px vertical rail, 4 entries: Files (active) · Search · People · Settings. Each = 34px icon button with a 2.5px left accent bar when active. In milestone 2 only Files routes anywhere; the others render but are `disabled` with tooltip "Not migrated yet." No invented content.
+
+### `LeftNavComponent`
+
+180px. Two sections with small uppercase labels (WORKSPACE / SHARED):
+
+- **Workspace**: Recents / Personal / Spaces
+- **Shared**: collapsible group with With me / With others / Via links
+- Divider → Trash
+- Bottom user card (avatar + display name + `used/quota` monoline from `UserService`)
+- Footer: AGPL §13 source link ("Source: github.com/zjean/server") — discharges the network-clause obligation for v2.
+
+Active state uses `--si-nav-soft` background + 2.5px glowing indigo bar on the left edge. Uses `routerLink` + `routerLinkActive`. Routes for unmigrated destinations (Spaces, Shared sub-items, Trash) render the target but the screen itself shows a "Not migrated yet — open in classic UI" placeholder.
+
+### `DockRailComponent`
+
+40px right rail, 6 toggleable tabs (pencil, bell, flag, info, shareTree, comment). Emits `(dockChange)`. Milestone-2 screens only wire `info`; the other tabs light up but open an empty "Coming soon" panel.
+
+## 5 · First-milestone screens
+
+### Recents — `/v2/recents`
+
+Two-panel layout, matches the real product structure.
+
+- **Left panel (~60%)**: "Files" header with count + search icon-button. Each row = `FileGlyph` (type-colored) + filename (with subfolder breadcrumb eyebrow) + right-aligned relative time in JetBrains Mono. Data from existing `RecentsService`. Click:
+  - Image → `/v2/viewer?id=…`
+  - Folder → `/v2/personal?path=…`
+  - Other → fall through to classic `files` route for m2 (graceful degradation).
+- **Right panel (~40%)**: "Comments" header + count. Rows = Avatar + author + file glyph + excerpt + time. Data from existing `CommentsService` if a recent-comments feed exists. If no feed is exposed, the panel shows the stripped-back "No recent comments" empty state — no invented data.
+- **Editorial greeting above both panels**: "Good morning, \<name>" in Instrument Serif italic. Name from `UserService`. No invented stat cards, no pinned row.
+
+### Personal browser — list view — `/v2/personal[/**]`
+
+- **Toolbar left**: refresh · new · upload · share · more (mirrors current product).
+- **Toolbar right**: `Filter ⌘F` search input + column-settings icon.
+- **Breadcrumbs**: pushed into `BreadcrumbService` on route activation, rendered by the shared title bar.
+- **Columns**: Name · Info · Size · Modified (matching real product). Name cell = `FileGlyph` + filename. Info cell shows comment-count pill if present. Modified as subtle warm-tinted pill in JetBrains Mono.
+- **Selection**: checkbox gutter appears on row hover. Selection toolbar replaces normal toolbar when ≥1 row selected.
+- **States**: empty state + loading skeleton.
+- **Grid / gallery**: toggles **rendered but disabled** with tooltip "Coming next". Segment positions are reserved so milestone 3 can drop them in without layout shift.
+
+### Viewer — `/v2/viewer`
+
+Dedicated dark canvas. Prev/next/play/fullscreen/info controls overlaid on the canvas. Opens image by `id` query param via `FilesService.getById`. Right `info` dock opens metadata panel reusing the existing file-info service. Keyboard: `←`/`→` to navigate siblings in the opener's list context; `Esc` closes back to referrer (Recents or Personal).
+
+## 6 · Build sequence (PRs)
+
+Each PR is an independent feature branch off `main`, merged via squash. `test` status check must pass; all PR conversations resolved before merge. All v2 code lives under `custom-v2/` so weekly upstream syncs land cleanly.
+
+| # | Branch | Contents | Est. LOC |
+|---|---|---|---|
+| 1 | `feat/v2-scaffold` | Empty `custom-v2/` skeleton, `/v2` route with a stub "Sync-In v2 — coming soon" page, `.v2-root` class wired up, tokens SCSS, three font packages, opt-in toggles in classic navbar user menu. | ~200 |
+| 2 | `feat/v2-icons-and-primitives` | `IconsV2Component` with all ~30 SVGs. `AvatarComponent`, `AvatarStackComponent`, `FileGlyphComponent`, `LogoComponent`, `PillComponent`, `ButtonComponent`, `IconButtonComponent`. Visual showcase route `/v2/_kit` for review. | ~500 |
+| 3 | `feat/v2-chrome` | `LayoutV2Component` + title bar + app rail + left nav + dock rail + `BreadcrumbService`. Routes still render stubs. | ~600 |
+| 4 | `feat/v2-recents` | Recents screen wired to `RecentsService` + `CommentsService`. | ~300 |
+| 5 | `feat/v2-personal-list` | Personal browser list view wired to `FilesService`: breadcrumb navigation, multi-select, toolbar, selection toolbar, empty/loading states. | ~700 |
+| 6 | `feat/v2-viewer` | Image viewer: keyboard + overlay controls, info dock. | ~300 |
+
+After each PR, `/v2` remains usable — unmigrated screens render placeholders until their PR lands.
+
+## 7 · Risks and mitigations
+
+- **Service shape surprises** — `RecentsService` / `CommentsService` may not expose the shape the design assumes. *Mitigation*: spike the service contract at the start of each screen PR; if there's a gap, add a thin adapter inside `custom-v2/adapters/` or trim the design to match real data. Never invent.
+- **`oklch()` browser support** — Safari <15.4 doesn't parse `oklch()`. *Mitigation*: tokens SCSS emits hex/rgb fallbacks alongside `oklch()`; verify against the fork's supported-browser matrix before merging the tokens PR.
+- **Upstream drift during build** — each PR is small and merged promptly to avoid long-lived branches. Weekly `upstream-sync.yml` only touches upstream files, not `custom-v2/` — collisions near-zero.
+- **AGPL §13 source link** — v2 must preserve or add the source-link to `github.com/zjean/server` somewhere visible. Placed in the user card footer of `LeftNavComponent`.
+- **i18n** — all v2 strings use the `custom.` prefix. Translation keys added to `src/app/i18n/` per existing pattern.
+
+## 8 · What's next
+
+- This document is approved; implementation follows PR sequence in § 6.
+- After milestone 2 (PRs 1–6) lands, a milestone-3 plan will cover: Spaces, Shared, Trash, File detail page, Transfers popover, grid/gallery views, Search, Settings, People.

--- a/environment/environment.dev.dist.yaml
+++ b/environment/environment.dev.dist.yaml
@@ -23,6 +23,24 @@ websocket:
   adapter: cluster
   corsOrigin: '*'
 
+# Dev-only secrets — safe to commit because this is a template for local machines.
+# Generate fresh random values if you're paranoid: `openssl rand -hex 32`.
+auth:
+  provider: mysql
+  encryptionKey: dev-encryption-key-do-not-use-in-prod
+  token:
+    access:
+      secret: dev-access-secret-do-not-use-in-prod
+      expiration: 30m
+    refresh:
+      secret: dev-refresh-secret-do-not-use-in-prod
+      expiration: 4h
+
 applications:
   files:
     dataPath: /tmp/sync-in-dev-data
+    onlyoffice:
+      enabled: false
+      secret: dev-onlyoffice-secret
+    collabora:
+      enabled: false

--- a/environment/environment.dev.dist.yaml
+++ b/environment/environment.dev.dist.yaml
@@ -1,0 +1,28 @@
+server:
+  host: 0.0.0.0
+  port: 8080
+  workers: 1
+  trustProxy: 1
+  restartOnFailure: false
+
+logger:
+  level: debug
+  stdout: true
+  colorize: true
+  jsonOutput: false
+
+mysql:
+  url: mysql://sync_in:dev@localhost:3307/sync_in
+  logQueries: false
+
+cache:
+  adapter: mysql
+  ttl: 60
+
+websocket:
+  adapter: cluster
+  corsOrigin: '*'
+
+applications:
+  files:
+    dataPath: /tmp/sync-in-dev-data

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -71,6 +71,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "frontend:build:production"

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,13 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true
+  },
+  "/socket.io": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "ws": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -85,7 +85,13 @@
     "docker:build": "docker build -t $npm_package_name .",
     "docker:buildx": "docker buildx build --platform linux/arm64,linux/amd64 --tag syncin/server:latest --tag syncin/server:${npm_package_version} --tag syncin/server:$(echo ${npm_package_version} | cut -d. -f1) . --push",
     "docker:buildx:dev": "docker buildx build --platform linux/arm64,linux/amd64 --tag syncin/server:dev . --push",
-    "docker:start": "docker run --name sync-in -it --rm -e SKIP_INIT=true -p 8080:8080 -v ./environment/environment.yaml:/app/environment/environment.yaml $npm_package_name"
+    "docker:start": "docker run --name sync-in -it --rm -e SKIP_INIT=true -p 8080:8080 -v ./environment/environment.yaml:/app/environment/environment.yaml $npm_package_name",
+    "dev:db": "docker compose -f docker/docker-compose.dev.yaml up -d --wait mariadb",
+    "dev:db:down": "docker compose -f docker/docker-compose.dev.yaml down",
+    "dev:db:reset": "docker compose -f docker/docker-compose.dev.yaml down -v && npm run dev:db",
+    "dev:migrate": "npm -w backend run db:migrate",
+    "dev:backend": "npm -w backend run start:dev",
+    "dev:frontend": "npm -w frontend start"
   },
   "devDependencies": {
     "commit-and-tag-version": "^12.5.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "dev:db:down": "docker compose -f docker/docker-compose.dev.yaml down",
     "dev:db:reset": "docker compose -f docker/docker-compose.dev.yaml down -v && npm run dev:db",
     "dev:migrate": "npm -w backend run db:migrate",
+    "dev:seed": "npm -w backend run db:seed",
     "dev:backend": "npm -w backend run start:dev",
     "dev:frontend": "npm -w frontend start"
   },


### PR DESCRIPTION
## Summary
- Adopts **parallel route tree**: new UI at `/v2/*`, classic UI untouched at `/*`, all under `custom-v2/` for fork isolation.
- Milestone 2 scope: scaffold + chrome (title bar · app rail · left nav · dock rail) + Recents + Personal browser list view + Viewer. Grid/gallery, File detail, Spaces, Shared, Trash, Transfers, Search, Settings, People deferred to milestone 3.
- Reuses existing Angular services (`FilesService`, `RecentsService`, `CommentsService`, `UserService`, …) — no duplication, thin adapters only where a service shape doesn't fit.
- Tokens ported from the design bundle (warm amber accent, indigo nav, flat plum title bar, Geist + Instrument Serif + JetBrains Mono) into scoped SCSS custom properties under `.v2-root`; oklch fallbacks planned. ~30 SVG icons ported as `IconsV2Component`.
- Six-PR build sequence mapped out: scaffold → primitives → chrome → Recents → Personal list → Viewer.

## Test plan
- [ ] Design doc renders on GitHub without broken links/headings
- [ ] No code changes, no behavior change — `test` check should be green