### PR TITLE
fix(backend:auth): tolerate OIDC avatar downloads using maxSize guard

### DIFF
--- a/backend/src/applications/files/interfaces/download-file.interface.ts
+++ b/backend/src/applications/files/interfaces/download-file.interface.ts
@@ -10,4 +10,5 @@ export interface DownloadFileOptions {
   allowPrivateIP?: boolean
   space?: SpaceEnv
   getContentInfo?: boolean
+  maxSize?: number
 }

--- a/backend/src/applications/files/utils/download-file.spec.ts
+++ b/backend/src/applications/files/utils/download-file.spec.ts
@@ -238,6 +238,48 @@ describe(DownloadFile.name, () => {
     expect(writeFromStream).not.toHaveBeenCalled()
   })
 
+  it('allows missing content-length when maxSize is provided', async () => {
+    const stream = Readable.from(['abc'])
+    http.axiosRef.mockResolvedValueOnce(response('8.8.8.8')).mockResolvedValueOnce({ ...response('8.8.8.8'), data: stream })
+
+    await new DownloadFile(http as unknown as HttpService).download({ url: 'https://example.test/file.txt' }, '/tmp/file.txt', {
+      maxSize: 1024
+    })
+
+    expect(writeFromStream).toHaveBeenCalledWith('/tmp/file.txt', stream, 0, 1024)
+  })
+
+  it('rejects missing content-length for space downloads even when maxSize is provided', async () => {
+    const space = { willExceedQuota: jest.fn() }
+    http.axiosRef.mockResolvedValueOnce(response('8.8.8.8'))
+
+    await expect(
+      new DownloadFile(http as unknown as HttpService).download({ url: 'https://example.test/file.txt' }, '/tmp/file.txt', {
+        space: space as any,
+        maxSize: 1024
+      })
+    ).rejects.toEqual(new FileError(HttpStatus.BAD_REQUEST, FILE_ERROR_MESSAGES.DOWNLOAD_INVALID_CONTENT_LENGTH))
+
+    expect(space.willExceedQuota).not.toHaveBeenCalled()
+    expect(writeFromStream).not.toHaveBeenCalled()
+  })
+
+  it('keeps content-length as the stream guard for space downloads even when maxSize is provided', async () => {
+    const stream = Readable.from(['abc'])
+    const space = { willExceedQuota: jest.fn().mockReturnValue(false) }
+    http.axiosRef
+      .mockResolvedValueOnce(response('8.8.8.8', { 'content-length': '12' }))
+      .mockResolvedValueOnce({ ...response('8.8.8.8'), data: stream })
+
+    await new DownloadFile(http as unknown as HttpService).download({ url: 'https://example.test/file.txt' }, '/tmp/file.txt', {
+      space: space as any,
+      maxSize: 1024
+    })
+
+    expect(space.willExceedQuota).toHaveBeenCalledWith(12)
+    expect(writeFromStream).toHaveBeenCalledWith('/tmp/file.txt', stream, 0, 12)
+  })
+
   it('allows zero content-length and guards the written stream at zero bytes', async () => {
     const stream = Readable.from([])
     http.axiosRef
@@ -288,5 +330,18 @@ describe(DownloadFile.name, () => {
         maxRedirects: 0
       })
     )
+  })
+
+  it('uses maxSize as the stream guard when provided', async () => {
+    const stream = Readable.from(['abc'])
+    http.axiosRef
+      .mockResolvedValueOnce(response('8.8.8.8', { 'content-length': '12' }))
+      .mockResolvedValueOnce({ ...response('8.8.8.8'), data: stream })
+
+    await new DownloadFile(http as unknown as HttpService).download({ url: 'https://example.test/file.txt' }, '/tmp/file.txt', {
+      maxSize: 1024
+    })
+
+    expect(writeFromStream).toHaveBeenCalledWith('/tmp/file.txt', stream, 0, 1024)
   })
 })

--- a/backend/src/applications/files/utils/download-file.ts
+++ b/backend/src/applications/files/utils/download-file.ts
@@ -37,12 +37,12 @@ export class DownloadFile {
   async download(
     downloadDto: DownloadFileDto,
     dstPath: string,
-    options: { allowPrivateIP?: boolean; space?: SpaceEnv; getContentInfo: true }
+    options: { allowPrivateIP?: boolean; space?: SpaceEnv; getContentInfo: true; maxSize?: number }
   ): Promise<DownloadFileContentInfo>
   async download(
     downloadDto: DownloadFileDto,
     dstPath: string,
-    options?: { allowPrivateIP?: boolean; space?: SpaceEnv; getContentInfo?: false | undefined }
+    options?: { allowPrivateIP?: boolean; space?: SpaceEnv; getContentInfo?: false | undefined; maxSize?: number }
   ): Promise<void>
   async download(downloadDto: DownloadFileDto, dstPath: string, options?: DownloadFileOptions): Promise<void | DownloadFileContentInfo> {
     const identityEncodingConfig = { decompress: false, headers: { 'Accept-Encoding': 'identity' } }
@@ -63,8 +63,11 @@ export class DownloadFile {
       } satisfies DownloadFileContentInfo
     }
 
-    if (contentLength === null) throw new FileError(HttpStatus.BAD_REQUEST, FILE_ERROR_MESSAGES.DOWNLOAD_INVALID_CONTENT_LENGTH)
-    this.prepareSpace(options?.space, contentLength, dstPath)
+    const maxSize = options?.space ? contentLength : (options?.maxSize ?? contentLength)
+    if (maxSize === null || (contentLength === null && options?.space)) {
+      throw new FileError(HttpStatus.BAD_REQUEST, FILE_ERROR_MESSAGES.DOWNLOAD_INVALID_CONTENT_LENGTH)
+    }
+    if (contentLength !== null) this.prepareSpace(options?.space, contentLength, dstPath)
 
     // The HEAD request resolved redirects; the GET must target that final URL directly.
     const { response: getRes } = await this.request(
@@ -72,7 +75,7 @@ export class DownloadFile {
       { method: HTTP_METHOD.GET, responseType: 'stream', ...identityEncodingConfig },
       { allowPrivateIP: options?.allowPrivateIP, maxRedirects: 0 }
     )
-    await writeFromStream(dstPath, getRes.data, 0, contentLength)
+    await writeFromStream(dstPath, getRes.data, 0, maxSize)
   }
 
   private safeLookup(hostname: string, options: Parameters<LookupFunction>[1], cb: Parameters<LookupFunction>[2]): void {

--- a/backend/src/authentication/providers/oidc/auth-provider-oidc.service.spec.ts
+++ b/backend/src/authentication/providers/oidc/auth-provider-oidc.service.spec.ts
@@ -435,8 +435,37 @@ describe(AuthProviderOIDC.name, () => {
       await (service as any).updatePictureUrl(oidcUser, userInfo())
 
       expect(downloadSpy).toHaveBeenCalledTimes(2)
+      expect(downloadSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ url: 'https://cdn.example.test/avatar.jpg' }),
+        '/tmp/sync-in/alice/tmp/avatar.png',
+        { allowPrivateIP: true, maxSize: avatarUtils.USER_AVATAR_MAX_UPLOAD_SIZE }
+      )
       expect(convertSpy).toHaveBeenCalledWith('/tmp/sync-in/alice/tmp/avatar.png', '/tmp/sync-in/users/alice/avatar.png')
       expect(metadataSpy).toHaveBeenCalledWith('alice', 'https://cdn.example.test/avatar.jpg', 128, 'Mon, 01 Jan 2024 00:00:00 GMT')
+    })
+
+    it('downloads avatar when content length is missing and stores the actual downloaded size', async () => {
+      const downloadSpy = jest
+        .spyOn(DownloadFile.prototype, 'download')
+        .mockResolvedValueOnce({
+          contentType: 'image/png',
+          contentLength: null,
+          lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT'
+        } as any)
+        .mockResolvedValueOnce(undefined as any)
+      const metadataUnchangedSpy = jest.spyOn(avatarUtils, 'isAvatarMetadataUnchanged').mockResolvedValue(false)
+      jest.spyOn(filesUtils, 'fileSize').mockResolvedValue(1024)
+      jest.spyOn(UserModel, 'getHomePath').mockReturnValue('/tmp/sync-in/users/alice')
+      const convertSpy = jest.spyOn(imageUtils, 'convertTempImageToPng').mockResolvedValue(undefined)
+      const metadataSpy = jest.spyOn(avatarUtils, 'saveAvatarMetadata').mockResolvedValue(undefined)
+
+      await (service as any).updatePictureUrl(oidcUser, userInfo())
+
+      expect(downloadSpy).toHaveBeenCalledTimes(2)
+      expect(metadataUnchangedSpy).not.toHaveBeenCalled()
+      expect(convertSpy).toHaveBeenCalledWith('/tmp/sync-in/alice/tmp/avatar.png', '/tmp/sync-in/users/alice/avatar.png')
+      expect(metadataSpy).toHaveBeenCalledWith('alice', 'https://cdn.example.test/avatar.jpg', 1024, 'Mon, 01 Jan 2024 00:00:00 GMT')
     })
 
     it('stops after download when avatar size exceeds limit', async () => {

--- a/backend/src/authentication/providers/oidc/auth-provider-oidc.service.ts
+++ b/backend/src/authentication/providers/oidc/auth-provider-oidc.service.ts
@@ -449,12 +449,16 @@ export class AuthProviderOIDC implements AuthProvider {
         return
       }
 
-      if (!pictureContentLength || pictureContentLength > USER_AVATAR_MAX_UPLOAD_SIZE) {
+      if (pictureContentLength !== undefined && pictureContentLength > USER_AVATAR_MAX_UPLOAD_SIZE) {
         this.logger.warn({ tag: this.updatePictureUrl.name, msg: `picture content length is invalid: ${pictureContentLength}` })
         return
       }
 
-      if (await isAvatarMetadataUnchanged(user.login, pictureUrl, pictureContentLength, pictureLastModified)) {
+      if (
+        pictureContentLength !== undefined &&
+        pictureContentLength > 0 &&
+        (await isAvatarMetadataUnchanged(user.login, pictureUrl, pictureContentLength, pictureLastModified))
+      ) {
         this.logger.verbose({ tag: this.updatePictureUrl.name, msg: `avatar metadata unchanged, skipping update` })
         return
       }
@@ -465,7 +469,7 @@ export class AuthProviderOIDC implements AuthProvider {
     // download avatar (trust the url source)
     const userAvatarTmpPath = path.join(user.tmpPath, USER_AVATAR_FILE_NAME)
     try {
-      await downloader.download(downloadDto, userAvatarTmpPath, { allowPrivateIP: true })
+      await downloader.download(downloadDto, userAvatarTmpPath, { allowPrivateIP: true, maxSize: USER_AVATAR_MAX_UPLOAD_SIZE })
     } catch (e) {
       this.logger.warn({ tag: this.updatePictureUrl.name, msg: `download failed: ${e}` })
       return
@@ -483,7 +487,8 @@ export class AuthProviderOIDC implements AuthProvider {
     const userAvatarPath = path.join(UserModel.getHomePath(user.login), USER_AVATAR_FILE_NAME)
     try {
       await convertTempImageToPng(userAvatarTmpPath, userAvatarPath)
-      void saveAvatarMetadata(user.login, pictureUrl, pictureContentLength, pictureLastModified)
+      const avatarMetadataSize = pictureContentLength !== undefined && pictureContentLength > 0 ? pictureContentLength : avatarSize
+      void saveAvatarMetadata(user.login, pictureUrl, avatarMetadataSize, pictureLastModified)
     } catch (e) {
       this.logger.warn({ tag: this.updatePictureUrl.name, msg: `convert failed: ${e}` })
     } finally {

--- a/frontend/src/app/applications/files/components/viewers/files-viewer-markdown.component.scss
+++ b/frontend/src/app/applications/files/components/viewers/files-viewer-markdown.component.scss
@@ -159,7 +159,7 @@
     img,
     pre,
     .tableWrapper {
-      margin: 0 0 1rem;
+      margin: 0 0 0.75rem;
     }
 
     ul,


### PR DESCRIPTION
Resolves #204 