### PR TITLE
fix: mask password when logging Redis connection URLs

### DIFF
--- a/backend/src/common/functions.ts
+++ b/backend/src/common/functions.ts
@@ -76,6 +76,10 @@ export function anonymizePassword(obj: { password?: string; secrets?: string }) 
   return { ...obj, ...(obj?.password && { password: '********' }), ...(obj?.secrets && { secrets: '********' }) }
 }
 
+export function anonymizeRedisUrl(url: string): string {
+  return url.replace(/\/\/:([^@]*)@/, '//:********@')
+}
+
 export function splitFullName(fullName?: string): { firstName: string; lastName: string } {
   if (!fullName || !fullName.trim()) return { firstName: '', lastName: '' }
   const parts = fullName.trim().split(/\s+/)

--- a/backend/src/common/functions.ts
+++ b/backend/src/common/functions.ts
@@ -76,10 +76,6 @@ export function anonymizePassword(obj: { password?: string; secrets?: string }) 
   return { ...obj, ...(obj?.password && { password: '********' }), ...(obj?.secrets && { secrets: '********' }) }
 }
 
-export function anonymizeRedisUrl(url: string): string {
-  return url.replace(/\/\/:([^@]*)@/, '//:********@')
-}
-
 export function splitFullName(fullName?: string): { firstName: string; lastName: string } {
   if (!fullName || !fullName.trim()) return { firstName: '', lastName: '' }
   const parts = fullName.trim().split(/\s+/)

--- a/backend/src/infrastructure/cache/adapters/redis-cache.adapter.ts
+++ b/backend/src/infrastructure/cache/adapters/redis-cache.adapter.ts
@@ -2,8 +2,8 @@ import { Injectable, Logger } from '@nestjs/common'
 import { RedisClientOptions } from '@redis/client'
 import { createClient, RedisClientType } from 'redis'
 import { createCacheKeySlug } from '../../../common/shared'
-import { anonymizeRedisUrl } from '../../../common/functions'
 import { configuration } from '../../../configuration/config.environment'
+import { redactRedisUrl } from '../../utils'
 import { Cache } from '../cache.service'
 
 @Injectable()
@@ -12,6 +12,7 @@ export class RedisCacheAdapter implements Cache {
   infiniteExpiration = -1
   private readonly logger = new Logger(Cache.name.toUpperCase())
   private readonly client: RedisClientType
+  private readonly redactedRedisUrl = redactRedisUrl(configuration.cache.redis)
   private readonly reconnectOptions = { maxAttempts: 3, minConnectDelay: 1000, maxConnectDelay: 2000 }
 
   constructor() {
@@ -23,7 +24,7 @@ export class RedisCacheAdapter implements Cache {
 
   async onModuleInit() {
     this.client.on('error', (e: Error) => this.logger.error(e.message || e))
-    this.client.on('ready', () => this.logger.log(`Connected to Redis Server at ${anonymizeRedisUrl(this.client.options.url)}`))
+    this.client.on('ready', () => this.logger.log(`Connected to Redis Server at ${this.redactedRedisUrl}`))
     this.client.connect().catch((e: Error) => this.logger.error(e))
   }
 

--- a/backend/src/infrastructure/cache/adapters/redis-cache.adapter.ts
+++ b/backend/src/infrastructure/cache/adapters/redis-cache.adapter.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { RedisClientOptions } from '@redis/client'
 import { createClient, RedisClientType } from 'redis'
 import { createCacheKeySlug } from '../../../common/shared'
+import { anonymizeRedisUrl } from '../../../common/functions'
 import { configuration } from '../../../configuration/config.environment'
 import { Cache } from '../cache.service'
 
@@ -22,7 +23,7 @@ export class RedisCacheAdapter implements Cache {
 
   async onModuleInit() {
     this.client.on('error', (e: Error) => this.logger.error(e.message || e))
-    this.client.on('ready', () => this.logger.log(`Connected to Redis Server at ${this.client.options.url}`))
+    this.client.on('ready', () => this.logger.log(`Connected to Redis Server at ${anonymizeRedisUrl(this.client.options.url)}`))
     this.client.connect().catch((e: Error) => this.logger.error(e))
   }
 

--- a/backend/src/infrastructure/utils.spec.ts
+++ b/backend/src/infrastructure/utils.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { redactRedisUrl } from './utils'
+
+describe(redactRedisUrl.name, () => {
+  it.each([
+    ['redis://127.0.0.1:6379', 'redis://127.0.0.1:6379'],
+    ['redis://:password@127.0.0.1:6379', 'redis://:********@127.0.0.1:6379'],
+    ['redis://default:password@127.0.0.1:6379', 'redis://default:********@127.0.0.1:6379'],
+    ['rediss://user:p%40ssword@redis.example.com', 'rediss://user:********@redis.example.com']
+  ])('redacts the password from %s', (url, expected) => {
+    expect(redactRedisUrl(url)).toBe(expected)
+  })
+})

--- a/backend/src/infrastructure/utils.ts
+++ b/backend/src/infrastructure/utils.ts
@@ -1,0 +1,7 @@
+export function redactRedisUrl(url: string): string {
+  const parsedUrl = new URL(url)
+  if (!parsedUrl.password) return url
+
+  parsedUrl.password = '********'
+  return parsedUrl.toString()
+}

--- a/backend/src/infrastructure/websocket/adapters/redis.adapter.ts
+++ b/backend/src/infrastructure/websocket/adapters/redis.adapter.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common'
 import { IoAdapter } from '@nestjs/platform-socket.io'
 import { ServerOptions } from 'socket.io'
-import { loadOptionalModule } from '../../../common/functions'
+import { anonymizeRedisUrl, loadOptionalModule } from '../../../common/functions'
 
 export class RedisAdapter extends IoAdapter {
   private readonly logger = new Logger('WebSocketAdapter')
@@ -24,9 +24,9 @@ export class RedisAdapter extends IoAdapter {
     const pubClient = createClient({ url: redisUrl, socket: { noDelay: true, reconnectStrategy: this.reconnectStrategy } })
     const subClient = pubClient.duplicate()
     pubClient.on('error', (e: Error) => this.logger.error(`PubClient: ${e.message || e}`))
-    pubClient.on('ready', () => this.logger.log(`PubClient: Connected to Redis Server at ${pubClient.options.url}`))
+    pubClient.on('ready', () => this.logger.log(`PubClient: Connected to Redis Server at ${anonymizeRedisUrl(pubClient.options.url)}`))
     subClient.on('error', (e: Error) => this.logger.error(`SubClient: ${e.message || e}`))
-    subClient.on('ready', () => this.logger.log(`SubClient: Connected to Redis Server at ${subClient.options.url}`))
+    subClient.on('ready', () => this.logger.log(`SubClient: Connected to Redis Server at ${anonymizeRedisUrl(subClient.options.url)}`))
     pubClient.connect()
     subClient.connect()
     this.adapterConstructor = createAdapter(pubClient, subClient)

--- a/backend/src/infrastructure/websocket/adapters/redis.adapter.ts
+++ b/backend/src/infrastructure/websocket/adapters/redis.adapter.ts
@@ -1,7 +1,9 @@
 import { Logger } from '@nestjs/common'
 import { IoAdapter } from '@nestjs/platform-socket.io'
 import { ServerOptions } from 'socket.io'
-import { anonymizeRedisUrl, loadOptionalModule } from '../../../common/functions'
+import { loadOptionalModule } from '../../../common/functions'
+import { redactRedisUrl } from '../../utils'
+import type { WebSocketConfig } from '../web-socket.config'
 
 export class RedisAdapter extends IoAdapter {
   private readonly logger = new Logger('WebSocketAdapter')
@@ -18,15 +20,16 @@ export class RedisAdapter extends IoAdapter {
     }
   }
 
-  async connectToRedis(redisUrl: string): Promise<void> {
+  async connectToRedis(redisUrl: WebSocketConfig['redis']): Promise<void> {
+    const redactedRedisUrl = redactRedisUrl(redisUrl)
     const { createAdapter } = await loadOptionalModule('@socket.io/redis-adapter')
     const { createClient } = await loadOptionalModule('redis')
     const pubClient = createClient({ url: redisUrl, socket: { noDelay: true, reconnectStrategy: this.reconnectStrategy } })
     const subClient = pubClient.duplicate()
     pubClient.on('error', (e: Error) => this.logger.error(`PubClient: ${e.message || e}`))
-    pubClient.on('ready', () => this.logger.log(`PubClient: Connected to Redis Server at ${anonymizeRedisUrl(pubClient.options.url)}`))
+    pubClient.on('ready', () => this.logger.log(`PubClient: Connected to Redis Server at ${redactedRedisUrl}`))
     subClient.on('error', (e: Error) => this.logger.error(`SubClient: ${e.message || e}`))
-    subClient.on('ready', () => this.logger.log(`SubClient: Connected to Redis Server at ${anonymizeRedisUrl(subClient.options.url)}`))
+    subClient.on('ready', () => this.logger.log(`SubClient: Connected to Redis Server at ${redactedRedisUrl}`))
     pubClient.connect()
     subClient.connect()
     this.adapterConstructor = createAdapter(pubClient, subClient)


### PR DESCRIPTION
Redis connection URLs (including the embedded password, e.g. `redis://:PASSWORD@host:port`) were logged in plaintext at startup for both the cache adapter and the websocket Redis adapter. This exposes the Redis password in server logs, `docker logs` output, and any log aggregation pipeline.

## Fix 

Added a new `anonymizeRedisUrl()` helper in `common/functions.ts`, following the same masking convention as the existing
`anonymizePassword()` helper (`'********'`).
Applied it to the three `ready` event log lines that previously logged the raw connection URL:
- `infrastructure/cache/adapters/redis-cache.adapter.ts`
- `infrastructure/websocket/adapters/redis.adapter.ts` (PubClient and SubClient)